### PR TITLE
feat: Store benchmark results on database

### DIFF
--- a/jasnah/benchmark.py
+++ b/jasnah/benchmark.py
@@ -1,11 +1,14 @@
 import concurrent.futures
+import json
 from dataclasses import dataclass
+from functools import partial
 from itertools import islice
-from typing import Optional, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 from datasets import Dataset, DatasetDict
 from tqdm import tqdm
 
+from jasnah.db import db
 from jasnah.solvers import SolverStrategy
 
 
@@ -26,24 +29,27 @@ class DatasetInfo:
 
 
 class BenchmarkExecutor:
-    def __init__(self, dataset_info: DatasetInfo, solver_strategy: SolverStrategy):
+    def __init__(self, dataset_info: DatasetInfo, solver_strategy: SolverStrategy, benchmark_id: int):
         self.dataset_info = dataset_info
         self.solver_strategy = solver_strategy
+        self.benchmark_id = benchmark_id
 
     def run(self, progress: bool = True, max_concurrent: int = 32) -> None:
         dataset = self.dataset_info.get_dataset()
 
+        cache = db.get_benchmark_status(self.benchmark_id)
+
         correct = 0
         remaining = len(dataset)
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            tasks = iter(executor.submit(self.solver_strategy.solve, datum=datum) for datum in dataset)
+            task_ctor = partial(solve_task, benchmark_id=self.benchmark_id, cache=cache, solve_fn=self.solver_strategy.solve)
+            tasks = iter(executor.submit(task_ctor, index=index, datum=datum) for index, datum in enumerate(dataset))
+
             total = len(dataset)
             bar = tqdm(total=total, disable=not progress)
             futures = list(islice(tasks, max_concurrent))
             while futures:
-                completed, ongoing_futures = concurrent.futures.wait(
-                    futures, return_when=concurrent.futures.FIRST_COMPLETED
-                )
+                completed, ongoing_futures = concurrent.futures.wait(futures, return_when=concurrent.futures.FIRST_COMPLETED)
                 futures = list(ongoing_futures)
                 for completed_future in completed:
                     bar.update(1)
@@ -52,9 +58,7 @@ class BenchmarkExecutor:
                     result = completed_future.result()
                     if result:
                         correct += 1
-                    bar.set_description(
-                        f"Correct/Seen - {correct}/{total - remaining} - {correct/(total - remaining):.2%}"
-                    )
+                    bar.set_description(f"Correct/Seen - {correct}/{total - remaining} - {correct/(total - remaining):.2%}")
 
                     try:
                         next_task = next(tasks)
@@ -63,3 +67,18 @@ class BenchmarkExecutor:
                         continue
 
         print(f"Final score: {correct}/{total} - {correct/total:.2%}")
+
+
+def solve_task(benchmark_id: int, cache: Dict[int, bool], solve_fn: Callable[[Any], Union[bool, Tuple[bool, Any]]], index: int, datum: Any):
+    if index in cache:
+        return cache[index]
+
+    result = solve_fn(datum)
+    info = ""
+
+    if isinstance(result, tuple):
+        result, info = result
+
+    db.update_benchmark_result(benchmark_id, index, result, json.dumps(info))
+
+    return result

--- a/jasnah/cli.py
+++ b/jasnah/cli.py
@@ -1,9 +1,9 @@
-import asyncio
 import json
 import os
 import runpy
 import sys
 import textwrap
+from collections import OrderedDict
 from dataclasses import asdict
 from pathlib import Path
 from subprocess import check_output, run
@@ -294,9 +294,18 @@ class BenchmarkCli:
         dataset: str,
         solver_strategy: str,
         max_concurrent: int = -1,
+        force: bool = False,
         subset: str = None,
         **solver_kwargs,
     ):
+        """
+        Run benchmark on a dataset with a solver strategy.
+
+        It will cache the results in the database and subsequent runs will pull the results from the cache.
+        If force is set to True, it will run the benchmark again and update the cache.
+        """
+        benchmark_id = db.get_benchmark_id(dataset, solver_strategy, force, subset=subset, **solver_kwargs)
+
         name, subset, dataset = dataset, subset, load_dataset(dataset)
 
         solver_strategy: SolverStrategy | None = SolverStrategyRegistry.get(solver_strategy, None)
@@ -304,7 +313,7 @@ class BenchmarkCli:
         solver_strategy = solver_strategy(dataset_ref=dataset, **solver_kwargs)
         assert name in solver_strategy.compatible_datasets(), f"Solver strategy {solver_strategy} is not compatible with dataset {name}"
 
-        be = BenchmarkExecutor(DatasetInfo(name, subset, dataset), solver_strategy)
+        be = BenchmarkExecutor(DatasetInfo(name, subset, dataset), solver_strategy, benchmark_id=benchmark_id)
 
         max_concurrent = os.cpu_count() if max_concurrent < 0 else max_concurrent
         be.run(max_concurrent=max_concurrent)

--- a/jasnah/db.py
+++ b/jasnah/db.py
@@ -1,4 +1,5 @@
 import json
+from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime
 from functools import partial
@@ -157,11 +158,15 @@ class Tag:
 
 class DB:
     def __init__(self, *, host, port, user, password, database):
-        self._connection = pymysql.connect(host=host, port=port, user=user, password=password, database=database)
+        self.kwargs = dict(host=host, port=port, user=user, password=password, database=database)
+        self._connection = pymysql.connect(**self.kwargs)
 
     @property
     def connection(self):
-        self._connection.ping(reconnect=True)
+        try:
+            self._connection.ping(reconnect=True)
+        except pymysql.err.OperationalError:
+            self._connection = pymysql.connect(**self.kwargs)
         return self._connection
 
     def close(self):
@@ -453,9 +458,7 @@ class DB:
     def get_registry_entry_by_path(self, path: str, version=None) -> Optional[RegistryEntry]:
         assert version == None, "Can not select version when path provided"
         with self.connection.cursor() as cursor:
-            cursor.execute(
-                f"SELECT * FROM {REGISTRY_TABLE} WHERE path=%s ORDER BY {REGISTRY_TABLE}.id DESC LIMIT 1", (path,)
-            )
+            cursor.execute(f"SELECT * FROM {REGISTRY_TABLE} WHERE path=%s ORDER BY {REGISTRY_TABLE}.id DESC LIMIT 1", (path,))
             result = cursor.fetchone()
             if not result:
                 return None
@@ -465,14 +468,9 @@ class DB:
         """Retrieves registry item by name and version if provided."""
         with self.connection.cursor() as cursor:
             if not version:
-                cursor.execute(
-                    f"SELECT * FROM {REGISTRY_TABLE} WHERE name=%s ORDER BY {REGISTRY_TABLE}.id DESC LIMIT 1", (name,)
-                )
+                cursor.execute(f"SELECT * FROM {REGISTRY_TABLE} WHERE name=%s ORDER BY {REGISTRY_TABLE}.id DESC LIMIT 1", (name,))
             else:
-                print(
-                    "SELECT * FROM {REGISTRY_TABLE} WHERE name='%s' AND {REGISTRY_TABLE}.path LIKE '%%/v%s' ORDER BY {REGISTRY_TABLE}.id DESC LIMIT 1"
-                    % (name, version)
-                )
+                print("SELECT * FROM {REGISTRY_TABLE} WHERE name='%s' AND {REGISTRY_TABLE}.path LIKE '%%/v%s' ORDER BY {REGISTRY_TABLE}.id DESC LIMIT 1" % (name, version))
                 cursor.execute(
                     f"SELECT * FROM {REGISTRY_TABLE} WHERE name=%s AND {REGISTRY_TABLE}.path LIKE '%%%s' ORDER BY {REGISTRY_TABLE}.id DESC LIMIT 1",
                     (name, version),
@@ -490,9 +488,7 @@ class DB:
                 return None
             return RegistryEntry.from_db(result)
 
-    def get_registry_entry_by_identifier(
-        self, identifier: Union[str, int], version: Optional[str] = None, fail_if_not_found=True
-    ) -> Optional[RegistryEntry]:
+    def get_registry_entry_by_identifier(self, identifier: Union[str, int], version: Optional[str] = None, fail_if_not_found=True) -> Optional[RegistryEntry]:
         try:
             identifier = int(identifier)
             entry = self.get_registry_entry_by_id(identifier)
@@ -506,6 +502,41 @@ class DB:
             raise ValueError(f"{identifier} not found in the registry")
 
         return entry
+
+    def get_benchmark_id(self, dataset: str, strategy: str, force: bool, **kwargs):
+        # Sorted arguments to ensure consistency
+        args = json.dumps(OrderedDict(sorted(kwargs.items())))
+
+        # Check if exists
+        if not force:
+            with self.connection.cursor() as cursor:
+                cursor.execute("SELECT * FROM benchmark WHERE name=%s AND solver=%s AND args=%s ORDER BY id DESC LIMIT 1", (dataset, strategy, args))
+                row = cursor.fetchone()
+
+                if row is not None:
+                    return row[0]
+
+        with self.connection.cursor() as cursor:
+            cursor.execute("INSERT INTO benchmark (name, solver, args) VALUES (%s, %s, %s)", (dataset, strategy, args))
+            return cursor.lastrowid
+
+    def get_benchmark_results(self, benchmark_id: int) -> Dict[int, Tuple[bool, str]]:
+        with self.connection.cursor() as cursor:
+            cursor.execute("SELECT dataset_index, result, info FROM benchmark_datum WHERE benchmark_id=%s", (benchmark_id,))
+            return {index: (result, info) for index, result, info in cursor.fetchall()}
+
+    def get_benchmark_status(self, benchmark_id: int) -> Dict[int, bool]:
+        with self.connection.cursor() as cursor:
+            cursor.execute("SELECT dataset_index, result FROM benchmark_datum WHERE benchmark_id=%s", (benchmark_id,))
+            return {index: result for index, result in cursor.fetchall()}
+
+    def update_benchmark_result(self, benchmark_id: int, index: int, result: bool, info: str):
+        with self.connection.cursor() as cursor:
+            cursor.execute(
+                "INSERT INTO benchmark_datum (benchmark_id, dataset_index, result, info) VALUES (%s, %s, %s, %s)",
+                (benchmark_id, index, result, info),
+            )
+        self.connection.commit()
 
     def add_tag(self, *, registry_id: int, tag: str):
         with self.connection.cursor() as cursor:
@@ -604,6 +635,25 @@ class DB:
                         )"""
             )
 
+            cursor.execute(
+                """CREATE TABLE IF NOT EXISTS benchmark(
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    name VARCHAR(255) NOT NULL,
+                    solver VARCHAR(255) NOT NULL,
+                    args TEXT NOT NULL
+                )"""
+            )
+
+            cursor.execute(
+                """CREATE TABLE IF NOT EXISTS benchmark_datum(
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    benchmark_id INT NOT NULL,
+                    dataset_index INT NOT NULL,
+                    result BOOLEAN NOT NULL,
+                    info TEXT
+                )"""
+            )
+
         self.connection.commit()
 
     def _check_all(self):
@@ -657,6 +707,9 @@ db: DB = LazyObject(connect)
 
 
 class CLI:
+    def create(self):
+        db._create()
+
     def ping(self):
         db.log(origin="test", target="test", content={"content": "this is a test"})
 

--- a/jasnah/solvers/__init__.py
+++ b/jasnah/solvers/__init__.py
@@ -1,15 +1,5 @@
-import ast
-import re
 from abc import ABC, ABCMeta, abstractmethod
-from itertools import islice
-from typing import Any, Callable, Dict, List, Type, Union
-
-from datasets import Dataset, DatasetDict
-from jinja2 import Template
-from openai.types.chat import ChatCompletion
-from pydantic import BaseModel
-
-from jasnah.config import PROMPTS_FOLDER
+from typing import Any, Dict, List, Type, Union, Tuple, Any
 
 
 class SolverStrategyMeta(ABCMeta):
@@ -40,7 +30,7 @@ class SolverStrategy(ABC, metaclass=SolverStrategyMeta):
     def compatible_datasets(self) -> List[str]: ...
 
     @abstractmethod
-    def solve(self, datum: dict) -> bool: ...
+    def solve(self, datum: dict) -> Union[bool, Tuple[bool, Any]]: ...
 
 
 SolverStrategyRegistry: Dict[str, Type[SolverStrategy]] = {}
@@ -48,3 +38,5 @@ SolverStrategyRegistry: Dict[str, Type[SolverStrategy]] = {}
 from jasnah.solvers.ddot_v0_solver import DDOTSV0Solver
 from jasnah.solvers.mbpp_solver import MBPPSolverStrategy
 from jasnah.solvers.mbpp_agent_solver import MBPPSolverAgent
+
+__all__ = ["SolverStrategyRegistry", "DDOTSV0Solver", "MBPPSolverStrategy", "MBPPSolverAgent"]

--- a/jasnah/solvers/ddot_v0_solver.py
+++ b/jasnah/solvers/ddot_v0_solver.py
@@ -141,9 +141,9 @@ class DDOTSV0Solver(SolverStrategy):
         print("Saving trajectories to", self._saved_trajectories)
 
     def compatible_datasets(self) -> List[str]:
-        return ["ddots_codeforces_small/v0"]
+        return ["ddots_codeforces_small/v0", "datasets/ddots_codeforces_medium_A_B/v0"]
 
-    def solve(self, datum: dict):
+    def solve(self, datum: dict) -> bool:
         problem_id = datum['problem_id']
         description = datum['description']
 


### PR DESCRIPTION
Store in the database the result for running a benchmark with a given solver. It remembers the arguments, so if any argument change the benchmark will run from scratch.

Re-running the benchmark will just download the result from the database, and finish inmediately