### PR TITLE
hub: update `/models` endpoint to return all models from all providers.

### DIFF
--- a/hub/demo/src/app/_components/chat.tsx
+++ b/hub/demo/src/app/_components/chat.tsx
@@ -40,7 +40,7 @@ export function Chat() {
 
   const form = useZodForm(chatCompletionsModel);
   const chat = useSendCompletionsRequest();
-  const listModels = useListModels();
+  const listModels = useListModels(form.watch("provider"));
   const [conversation, setConversation] = useState<
     z.infer<typeof messageModel>[]
   >([]);

--- a/hub/demo/src/hooks/queries.ts
+++ b/hub/demo/src/hooks/queries.ts
@@ -1,17 +1,31 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "~/trpc/react";
 
-export function useListModels() {
+const PROVIDER_MODEL_SEP = "::";
+
+export function useListModels(provider: string) {
   const listModels = api.router.listModels.useQuery();
 
   return useQuery({
-    queryKey: ["listModels"],
+    queryKey: ["listModels", provider],
     queryFn: () => {
       console.log("listModels", listModels.data);
 
-      const m = listModels.data?.data.map((m) => {
-        return { label: m.id, value: m.id };
-      });
+      const m = listModels.data?.data
+        .map((m) => {
+          if (!m.supports_chat) {
+            return null;
+          }
+          // filter out models that don't belong to the currently selected provider
+          if (!m.id.includes(provider + PROVIDER_MODEL_SEP)) {
+            return null;
+          }
+          return {
+            label: m.id.replace(provider + PROVIDER_MODEL_SEP, ""),
+            value: m.id,
+          };
+        })
+        .filter(Boolean) as { label: string; value: string }[];
 
       console.log("models", m);
 

--- a/hub/demo/src/lib/models.ts
+++ b/hub/demo/src/lib/models.ts
@@ -30,14 +30,14 @@ export const chatResponseModel = z.object({
     z.object({
       finish_reason: z.string(),
       index: z.number(),
-      logprobs: z.nullable(z.unknown()),
+      logprobs: z.unknown().nullable(),
       message: messageModel,
     }),
   ),
   created: z.number(),
   model: z.string(),
   object: z.string(),
-  system_fingerprint: z.nullable(z.unknown()),
+  system_fingerprint: z.unknown().nullable(),
   usage: z.object({
     completion_tokens: z.number(),
     prompt_tokens: z.number(),
@@ -54,11 +54,11 @@ export const oneModelModel = z.object({
   created: z.number(),
   object: z.string(),
   owned_by: z.string(),
-  number_of_inference_nodes: z.optional(z.number()),
+  number_of_inference_nodes: z.number().nullable().optional(),
   supports_chat: z.boolean(),
   supports_image_input: z.boolean(),
   supports_tools: z.boolean(),
-  context_length: z.optional(z.number()),
+  context_length: z.number().nullable().optional(),
 });
 
 export const listModelsResponseModel = z.object({


### PR DESCRIPTION
- Updated UI accordingly. 
  - Now filters out non "chat" models.

Example response:

```
{
    "object": "list",
    "data": [
        {
            "id": "hyperbolic::StableDiffusion",
            "created": 1721314020,
            "object": "model",
            "owned_by": "Hyperbolic",
            "number_of_inference_nodes": null,
            "supports_chat": false,
            "supports_image_input": true,
            "supports_tools": false,
            "context_length": null
        },
...
        {
            "id": "fireworks::accounts/fireworks/models/mistral-7b-instruct-v3",
            "created": 1717022258,
            "object": "model",
            "owned_by": "fireworks",
            "supports_chat": true,
            "supports_image_input": false,
            "supports_tools": true,
            "context_length": 32768
        }
    ]
}
```

Before (it was missing hyperbolic ones...):

```
{
    "object": "list",
    "data": [
        {
            "id": "accounts/fireworks/models/mistral-7b-instruct-v3",
            "created": 1717022258,
            "object": "model",
            "owned_by": "fireworks",
            "supports_chat": true,
            "supports_image_input": false,
            "supports_tools": true,
            "context_length": 32768
        },
...
    ]
}