### PR TITLE
Fix types to be py38 compatible  

### DIFF
--- a/jasnah/solvers/hellaswag_solver.py
+++ b/jasnah/solvers/hellaswag_solver.py
@@ -14,7 +14,7 @@ class HellaswagDatum(BaseModel):
     ctx: str
     ctx_a: str
     ctx_b: str
-    endings: list[str]
+    endings: List[str]
     ind: int
     label: str
     source_id: str

--- a/jasnah/solvers/mmlu_solver.py
+++ b/jasnah/solvers/mmlu_solver.py
@@ -12,7 +12,7 @@ from jasnah.completion import InferenceRouter
 class MMLUDatum(BaseModel):
     question: str
     subject: str
-    choices: list[str]
+    choices: List[str]
     answer: int
 
 


### PR DESCRIPTION
Fixing a runtime error caused by #18 . PR introduced typing only supported by >=3.10 . Typing is now changed to be backwards compatible. 

Tested to be 3.8 compatible via

```
python3.8 -m jasnah benchmark run mmlu MMLUSolverStrategy --model local/llama-v3-70b-instruct --subset test
```