### PR TITLE
feat: Improve start up time for CLI

### DIFF
--- a/nearai/environment.py
+++ b/nearai/environment.py
@@ -15,7 +15,8 @@ from shutil import rmtree
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 import psutil
-from litellm import Choices, CustomStreamWrapper, ModelResponse
+from litellm.types.utils import Choices, ModelResponse
+from litellm.utils import CustomStreamWrapper
 from openai.types.chat import ChatCompletionMessageParam
 from openapi_client import EntryMetadata
 

--- a/nearai/finetune/__init__.py
+++ b/nearai/finetune/__init__.py
@@ -13,7 +13,6 @@ from openapi_client import EntryMetadata
 import nearai
 from nearai import timestamp
 from nearai.config import CONFIG, DATA_FOLDER, ETC_FOLDER
-from nearai.dataset import get_dataset
 from nearai.model import get_model
 from nearai.registry import registry
 
@@ -48,6 +47,8 @@ class FinetuneCli:
             dataset_kwargs: Additional keyword arguments to pass to the dataset constructor.
 
         """  # noqa: E501
+        from nearai.dataset import get_dataset
+
         assert num_nodes >= 1
 
         # Prepare job id folder

--- a/nearai/lib.py
+++ b/nearai/lib.py
@@ -4,7 +4,7 @@ from datetime import timezone
 from pathlib import Path
 from typing import Any
 
-from openapi_client import EntryLocation
+from openapi_client.models.entry_location import EntryLocation
 
 from nearai.config import CONFIG
 

--- a/nearai/tensorboard_feed.py
+++ b/nearai/tensorboard_feed.py
@@ -5,8 +5,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
 
-import tensorboardX
-
 
 @dataclass
 class Log:
@@ -24,6 +22,8 @@ def get_logs(*args, **kwargs) -> List[Log]:
 
 class TensorboardCli:
     def start(self, logdir: str, limit: int = 100, timeout: int = 1) -> None:  # noqa: D102
+        import tensorboardX
+
         experiments: Dict[str, tensorboardX.SummaryWriter] = {}
 
         logdir_path = Path(logdir)


### PR DESCRIPTION
Before doing `nearai version` was taking >7s. The main culprit was several imports (specially litellm, tensorboardX, and datasets)

We delay imports as much as possible, so they are only done when necessary.

After this PR, it takes ~0.392s to start.

I was profiling using:

```
# Install tuna
pip install tuna

PYTHONPROFILEIMPORTTIME=1 nearai version 2> import_perf.log
tuna import_perf.log
```