### PR TITLE
Default value for api_url and minor readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,25 +31,16 @@ python3 -m pip install -e .
 nearai version
 ```
 
-## Setup basic configuration
-
-To setup configuration with a remote `nearai` database, run:
+To perform write operations you will need to log in with your Near account.
 
 ```
-nearai config set db_user <DB_USERNAME>
-nearai config set db_password <DB_PASSWORD>
-nearai config set user_name <YOUR_NAME>
+nearai login
 ```
 
-The user name will be used to identify the author of the experiments.
-This configuration can be manually edited at `~/.nearai/config.json`, or per project at `.nearai/config.json` (relative to the current directory).
+## Usage
 
-To use the registry (for downloading and uploading models and datasets) you need to setup access to S3. Do it by installing [aws-cli](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) and configuring it:
+To learn how to use NearAI, please read the [documentation](https://docs.near.ai/).
 
-```
-export AWS_ACCESS_KEY_ID=<..>
-export AWS_SECRET_ACCESS_KEY="<..>"
-```
 
 ## Update
 
@@ -63,10 +54,6 @@ git pull # Pull the latest changes
 python3 -m pip install -e .
 ```
 
-## Usage
-
-To learn how to use NearAI, please read the [documentation](docs.near.ai/).
-
 ## Contributing
 
-To contribute to NearAI, please read the [contributing guide](docs.near.ai/contributing/).
+To contribute to NearAI, please read the [contributing guide](https://docs.near.ai/contributing/).

--- a/nearai/config.py
+++ b/nearai/config.py
@@ -95,7 +95,7 @@ class Config(BaseModel):
     origin: Optional[str] = None
     user_name: Optional[str] = None
     user_email: Optional[str] = None
-    api_url: Optional[str] = None
+    api_url: Optional[str] = "https://api.near.ai"
     inference_url: str = "http://localhost:5000/v1/"
     inference_api_key: str = "n/a"
     nearai_hub: Optional[NearAiHubConfig] = NearAiHubConfig()


### PR DESCRIPTION
Let's make the cli work out of the box by having a default `api_url`.

Made some minor Readme changes since db setup is not needed anymore.