### PR TITLE
Update registry list | Fix filter by tags & add filter by namespace

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -55,14 +55,14 @@ The registry is a place to store models, datasets, agents, and environments (mor
     The registry is backed by an S3 bucket with metadata stored in a database.
 
 To upload an item to the registry, you need a directory containing a metadata.json file. The metadata.json file describes
-the item, and all the other files in the directory make up the item. For an agent that is one `agent.py` file, for a 
+the item, and all the other files in the directory make up the item. For an agent that is one `agent.py` file, for a
 dataset it may be hundreds of files.
 
 The metadata_template command will create a template for you to fill in.
 ```
 nearai registry metadata_template <ITEM_LOCAL_DIRECTORY_PATH>
 ```
-Fill in name, version, category and any other fields for which you have values. 
+Fill in name, version, category and any other fields for which you have values.
 The current categories are: `model`, `dataset`, `agent`, `environment`.
 
 ```json
@@ -85,25 +85,34 @@ Upload an element to the registry using:
 nearai registry upload <ITEM_LOCAL_DIRECTORY_PATH>
 ```
 
+You can list elements in the registry using several filters:
+
+```shell
+nearai registry list  --namespace <NAMESPACE> \
+                      --category <CATEGORY> \
+                      --tags <COMMA_SEPARTED_LIST_OF_TAGS>
+                      --show_all
+```
+
 Check the item is available by listing all elements in the registry of that category:
 
-```
-nearai registry list --category agent
+```shell
+nearai registry list --namespace near.ai --category agent
 ```
 
 Show only items with the tag `quine` and `python`:
 
-```
+```shell
 nearai registry list --tags quine,python
 ```
 
-Download this element locally. To download refer to the item by <author>/<name>/<version>. Trying to download an item that was previously downloaded is a no-op.
+Download this element locally. To download refer to the item by <namespace>/<name>/<version>. Trying to download an item that was previously downloaded is a no-op.
 
 ```
 nearai registry download zavodil.near/hello-world-agent/1
 ```
 
-!!! tip 
+!!! tip
     If you start downloading and item, and cancel the download midway, you should delete the folder at `~/.nearai/registry/` to trigger a new download.
 
 Update the metadata of an item with the registry update command

--- a/nearai/cli.py
+++ b/nearai/cli.py
@@ -71,6 +71,7 @@ class RegistryCli:
 
     def list(
         self,
+        namespace: str = "",
         category: str = "",
         tags: str = "",
         total: int = 32,
@@ -81,7 +82,7 @@ class RegistryCli:
         tags_l = parse_tags(tags)
         tags = ",".join(tags_l)
 
-        entries = registry.list(category, tags, total, show_all)
+        entries = registry.list(namespace, category, tags, total, show_all)
 
         for entry in entries:
             print(entry)

--- a/nearai/registry.py
+++ b/nearai/registry.py
@@ -207,6 +207,7 @@ class Registry:
 
     def list(
         self,
+        namespace: str,
         category: str,
         tags: str,
         total: int,
@@ -214,6 +215,7 @@ class Registry:
     ) -> List[EntryLocation]:
         """List and filter entries in the registry."""
         return self.api.list_entries_v1_registry_list_entries_post(
+            namespace=namespace,
             category=category,
             tags=tags,
             total=total,

--- a/openapi_client/api/agents_assistants_api.py
+++ b/openapi_client/api/agents_assistants_api.py
@@ -642,7 +642,7 @@ class AgentsAssistantsApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '200': "bytearray",
+            '200': "object",
             '422': "HTTPValidationError",
         }
         response_data = self.api_client.call_api(

--- a/openapi_client/api/registry_api.py
+++ b/openapi_client/api/registry_api.py
@@ -588,6 +588,7 @@ class RegistryApi:
     @validate_call
     def list_entries_v1_registry_list_entries_post(
         self,
+        namespace: Optional[StrictStr] = None,
         category: Optional[StrictStr] = None,
         tags: Optional[StrictStr] = None,
         total: Optional[StrictInt] = None,
@@ -608,6 +609,8 @@ class RegistryApi:
         """List Entries
 
 
+        :param namespace:
+        :type namespace: str
         :param category:
         :type category: str
         :param tags:
@@ -639,6 +642,7 @@ class RegistryApi:
         """ # noqa: E501
 
         _param = self._list_entries_v1_registry_list_entries_post_serialize(
+            namespace=namespace,
             category=category,
             tags=tags,
             total=total,
@@ -667,6 +671,7 @@ class RegistryApi:
     @validate_call
     def list_entries_v1_registry_list_entries_post_with_http_info(
         self,
+        namespace: Optional[StrictStr] = None,
         category: Optional[StrictStr] = None,
         tags: Optional[StrictStr] = None,
         total: Optional[StrictInt] = None,
@@ -687,6 +692,8 @@ class RegistryApi:
         """List Entries
 
 
+        :param namespace:
+        :type namespace: str
         :param category:
         :type category: str
         :param tags:
@@ -718,6 +725,7 @@ class RegistryApi:
         """ # noqa: E501
 
         _param = self._list_entries_v1_registry_list_entries_post_serialize(
+            namespace=namespace,
             category=category,
             tags=tags,
             total=total,
@@ -746,6 +754,7 @@ class RegistryApi:
     @validate_call
     def list_entries_v1_registry_list_entries_post_without_preload_content(
         self,
+        namespace: Optional[StrictStr] = None,
         category: Optional[StrictStr] = None,
         tags: Optional[StrictStr] = None,
         total: Optional[StrictInt] = None,
@@ -766,6 +775,8 @@ class RegistryApi:
         """List Entries
 
 
+        :param namespace:
+        :type namespace: str
         :param category:
         :type category: str
         :param tags:
@@ -797,6 +808,7 @@ class RegistryApi:
         """ # noqa: E501
 
         _param = self._list_entries_v1_registry_list_entries_post_serialize(
+            namespace=namespace,
             category=category,
             tags=tags,
             total=total,
@@ -820,6 +832,7 @@ class RegistryApi:
 
     def _list_entries_v1_registry_list_entries_post_serialize(
         self,
+        namespace,
         category,
         tags,
         total,
@@ -844,6 +857,10 @@ class RegistryApi:
 
         # process the path parameters
         # process the query parameters
+        if namespace is not None:
+            
+            _query_params.append(('namespace', namespace))
+            
         if category is not None:
             
             _query_params.append(('category', category))

--- a/scripts/near-openapi.json
+++ b/scripts/near-openapi.json
@@ -486,6 +486,16 @@
         "operationId": "list_entries_v1_registry_list_entries_post",
         "parameters": [
           {
+            "name": "namespace",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "",
+              "title": "Namespace"
+            }
+          },
+          {
             "name": "category",
             "in": "query",
             "required": false,
@@ -681,7 +691,7 @@
               "application/gzip": {
                 "schema": {
                   "type": "string",
-                  "format": "byte"
+                  "format": "binary"
                 }
               }
             }
@@ -842,7 +852,8 @@
                 "type": "null"
               }
             ],
-            "title": "Provider"
+            "title": "Provider",
+            "default": "fireworks"
           },
           "max_tokens": {
             "anyOf": [
@@ -957,7 +968,8 @@
                 "type": "null"
               }
             ],
-            "title": "Provider"
+            "title": "Provider",
+            "default": "fireworks"
           },
           "max_tokens": {
             "anyOf": [


### PR DESCRIPTION
## Fix query by tags

A manual query to filter by tags was outdated with regard to other parts of the code. Now, filtering by tag works. Use multiple tags separated by commas.

```
nearai registry list --tags foo,bar
```

Fixes #161 

## Filter registry elements by namespace

```
nearai registry list --namespace near.ai
```

Fixes #160 

---

Better review this PR by checking the two individual commits f17174b07d363e98b5b6018309af75010746eed8 and 3f64954162f86e76182744160d3bbd92fd5ddd6c