### PR TITLE
Update navigation and layout components for better responsiveness and scrolling

### DIFF
--- a/hub/demo/src/app/_components/navigation.tsx
+++ b/hub/demo/src/app/_components/navigation.tsx
@@ -20,7 +20,7 @@ export function Navigation() {
 
   return (
     <HydrationZustand>
-      <div className="flex min-h-[100vh] min-w-[20%] flex-col justify-between gap-3 border-r-2 px-4 py-4">
+      <div className="flex h-screen w-64 flex-col justify-between gap-3 overflow-y-auto border-r-2 px-4 py-4">
         <div>
           <Three>AI Hub</Three>
           <div className="flex flex-col justify-between">

--- a/hub/demo/src/app/layout.tsx
+++ b/hub/demo/src/app/layout.tsx
@@ -20,11 +20,9 @@ export default function RootLayout({
     <html lang="en" className={`${GeistSans.variable}`}>
       <body>
         <TRPCReactProvider>
-          <main>
-            <div className="flex h-full w-full">
-              <Navigation />
-              <div className="flex-grow">{children}</div>
-            </div>
+          <main className="flex h-screen overflow-hidden">
+            <Navigation />
+            <div className="flex-grow overflow-y-auto">{children}</div>
           </main>
         </TRPCReactProvider>
       </body>


### PR DESCRIPTION
Fixes the scroll when content of the page is too long. Causing the sidebar to stay at the top of the page.

Issue:
<img width="1725" alt="Screenshot 2024-08-19 at 11 43 21" src="https://github.com/user-attachments/assets/727a6f3f-b66f-4cec-b60e-97205a755e3f">

Solved:
<img width="998" alt="Screenshot 2024-08-19 at 11 44 33" src="https://github.com/user-attachments/assets/b567f8c1-f342-4968-bd41-32256cc93c1e">
