### PR TITLE
Replace environment command naming with agent

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -13,10 +13,10 @@ from other systems such as a scheduler or indexer.
  * Write your agent, in agent.py, using the [environment api](#the-environment-api) described below.
  * Use your agent locally using the cli and passing it a folder to write output to.
 ```shell
-nearai environment interactive AGENT EXECUTION_FOLDER --local
+nearai agent interactive AGENT EXECUTION_FOLDER --local
 ```
 ```shell
-nearai environment interactive example_agent /tmp/example_agent_run_1 --local
+nearai agent interactive example_agent /tmp/example_agent_run_1 --local
 ```
 
 ## Example agent.py
@@ -45,19 +45,19 @@ nearai registry download flatirons.near/xela-agent/5
 Agents can be run interactively. The environment_path should be a folder where the agent chat record (chat.txt) and 
 other files can be written, usually `~/tmp/test-agents/<AGENT_NAME>-run-X`.
 
-* command `nearai environment interactive AGENT ENVIRONMENT_PATH`
+* command `nearai agent interactive AGENT ENVIRONMENT_PATH`
 * example 
 ```shell
-nearai environment interactive flatirons.near/xela-agent/5 /tmp/test-agents/xela-agent-run-1
+nearai agent interactive flatirons.near/xela-agent/5 /tmp/test-agents/xela-agent-run-1
 ```
 
 ### Running an agent as a task
 To run without user interaction pass the task input to the task
 
-* command `nearai environment task <AGENT> <INPUT> <ENVIRONMENT_PATH>`
+* command `nearai agent task <AGENT> <INPUT> <ENVIRONMENT_PATH>`
 * example 
 ```shell
-nearai environment task flatirons.near/xela-agent/5 "Build a command line chess engine" ~/tmp/test-agents/xela-agent/chess-engine
+nearai agent task flatirons.near/xela-agent/5 "Build a command line chess engine" ~/tmp/test-agents/xela-agent/chess-engine
 ```
 
 
@@ -137,19 +137,19 @@ response = env.completions_and_run_tools("llama-v3p1-405b-instruct", messages, t
  * Upload the agent `nearai registry upload ~/.nearai/registry/example_agent`
 
 ## Running an agent remotely through the CLI
-Agents can be run through the CLI using the `nearai environment run_remote` command.
+Agents can be run through the CLI using the `nearai agent run_remote` command.
 A new message can be passed with the new_message argument. A starting environment (state) can be passed with the environment_id argument.
 ```shell
-  nearai environment run_remote flatirons.near/example-travel-agent/1 \
+  nearai agent run_remote flatirons.near/example-travel-agent/1 \
   new_message="I would like to travel to Paris" \
   environment_id="flatirons.near/environment_run_example-travel-agent_541869e6753c41538c87cb6f681c6932/0""
  ```
 
 ## Running an agent through the API
-Agents can be run through the `/environments/runs` endpoint. You will need to pass a signed message to authenticate.
+Agents can be run through the `/agent/runs` endpoint. You will need to pass a signed message to authenticate.
 
 ```shell
-curl "https://api.near.ai/v1/environment/runs" \
+curl "https://api.near.ai/v1/agent/runs" \
       -X POST \
       --header 'Content-Type: application/json' \
       --header 'Authorization: Bearer {"account_id":"flatirons.near","public_key":"ed25519:F5DeKFoyF1CQ6wG6jYaXxwQeoksgi8a677JkniDBGBTB","signature":"kfiH7AStKrBaMXzwpE50yQ2TRTxksID9tNVEdazxtegEu6rwH6x575smcAJPAUfTtlT2l7xwXtapQkxd+vFUAg==","callback_url":"http://localhost:3000/","message":"Welcome to NEAR AI Hub!","recipient":"ai.near","nonce":"00000000000000000005722050769950"}' \

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,7 +24,7 @@
         merge_init_into_class: false
         group_by_category: false
 
-::: nearai.cli.EnvironmentCli
+::: nearai.cli.AgentCli
     options:
         show_root_heading: true
         merge_init_into_class: false

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ Features:
 
     - https://app.near.ai/settings
 
-Source code in: [demo](/hub/demo/)
+Source code in: [demo](https://github.com/nearai/nearai/hub/demo/)
 
 For the api specification see [openapi.json](https://api.near.ai/openapi.json)
 

--- a/hub/api/v1/agent_routes.py
+++ b/hub/api/v1/agent_routes.py
@@ -39,7 +39,7 @@ class CreateThreadAndRunRequest(BaseModel):
     )
     new_message: Optional[str] = Field(
         None,
-        description="A message to pass to the environment before running the agents.",
+        description="A message to add to the environment chat.txt before running the agents.",
     )
     max_iterations: Optional[int] = Field(
         10,
@@ -52,8 +52,8 @@ class CreateThreadAndRunRequest(BaseModel):
 
 
 @v1_router.post("/threads/runs", tags=["Agents", "Assistants"])  # OpenAI compatibility
-@v1_router.post("/environment/runs", tags=["Agents", "Assistants"])
-def create_environment_and_run(body: CreateThreadAndRunRequest, auth: AuthToken = Depends(revokable_auth)) -> str:
+@v1_router.post("/agent/runs", tags=["Agents", "Assistants"])
+def run_agent(body: CreateThreadAndRunRequest, auth: AuthToken = Depends(revokable_auth)) -> str:
     """Run an agent against an existing or a new environment.
 
     Returns the ID of the new environment resulting from the run.

--- a/nearai/cli.py
+++ b/nearai/cli.py
@@ -179,11 +179,7 @@ class BenchmarkCli:
         be.run(max_concurrent=max_concurrent)
 
 
-class EnvironmentCli:
-    def setup(self, dataset: str, task_id: int) -> None:
-        """Setup environment with given task from the dataset."""
-        pass
-
+class AgentCli:
     def inspect(self, path: str) -> None:
         """Inspect environment from given path."""
         from nearai.environment import Environment
@@ -199,7 +195,7 @@ class EnvironmentCli:
         env.save_folder(name)
 
     def save_from_history(self, name: Optional[str] = None) -> None:
-        """Reads piped history, finds agent task runs, writes start_command.log files, and saves to registry. For detailed usage, run: nearai environment save_from_history --help.
+        """Reads piped history, finds agent task runs, writes start_command.log files, and saves to registry. For detailed usage, run: nearai agent save_from_history --help.
 
         This command:
         1. Finds agent task runs (must contain non-empty chat.txt)
@@ -208,9 +204,9 @@ class EnvironmentCli:
 
         Only 'interactive' is supported.
         Assumes format:
-        ' <line_number>  <program_name> environment interactive <comma_separated_agents> <path> <other_args>'
+        ' <line_number>  <program_name> agent interactive <comma_separated_agents> <path> <other_args>'
         Run:
-        $ history | grep "environment interactive" | sed "s:~:$HOME:g" | nearai environment save_from_history environment_interactive_runs_from_lambda_00
+        $ history | grep "agent interactive" | sed "s:~:$HOME:g" | nearai agent save_from_history environment_interactive_runs_from_lambda_00
         """  # noqa: E501
         from nearai.environment import Environment
 
@@ -249,15 +245,6 @@ class EnvironmentCli:
         _agents = [load_agent(agent) for agent in agents.split(",")]
         env = Environment(path, _agents, CONFIG)
         env.run_task(task, record_run, load_env, max_iterations)
-
-    def run(self, agents: str, task: str, path: str) -> None:
-        """Runs agent in the current environment."""
-        from nearai.environment import Environment
-
-        _agents = [load_agent(agent) for agent in agents.split(",")]
-        env = Environment(path, [], CONFIG)
-        env.exec_command("sleep 10")
-        # TODO: Setup server that will allow to interact with agents and environment
 
     def run_remote(
         self,
@@ -395,7 +382,7 @@ class CLI:
 
         self.config = ConfigCli()
         self.benchmark = BenchmarkCli()
-        self.environment = EnvironmentCli()
+        self.agent = AgentCli()
         self.finetune = FinetuneCli()
         self.tensorboard = TensorboardCli()
         self.vllm = VllmCli()


### PR DESCRIPTION
New commands / endpoint are:

 * `nearai agent interactive`
 * `nearai agent task`
 * `nearai agent run_remote`
 * POST `/agent/runs`