### PR TITLE
feat: env vars in metadata & cmd for agents

### DIFF
--- a/nearai/cli.py
+++ b/nearai/cli.py
@@ -216,7 +216,13 @@ class AgentCli:
         env.save_from_history(lines, name)
 
     def interactive(
-        self, agents: str, path: Optional[str] = "", record_run: str = "true", load_env: str = "", local: bool = False
+        self,
+        agents: str,
+        path: Optional[str] = "",
+        record_run: str = "true",
+        env_vars: Optional[Dict[str, Any]] = None,
+        load_env: str = "",
+        local: bool = False,
     ) -> None:
         """Runs agent interactively with environment from given path."""
         from nearai.environment import Environment
@@ -227,7 +233,7 @@ class AgentCli:
                 path = _agents[0].path
             else:
                 raise ValueError("Local path is required when running multiple agents")
-        env = Environment(path, _agents, CONFIG)
+        env = Environment(path, _agents, CONFIG, env_vars=env_vars)
         env.run_interactive(record_run, load_env)
 
     def task(
@@ -237,6 +243,7 @@ class AgentCli:
         path: Optional[str] = "",
         max_iterations: int = 10,
         record_run: str = "true",
+        env_vars: Optional[Dict[str, Any]] = None,
         load_env: str = "",
         local: bool = False,
     ) -> None:
@@ -249,7 +256,7 @@ class AgentCli:
                 path = _agents[0].path
             else:
                 raise ValueError("Local path is required when running multiple agents")
-        env = Environment(path, _agents, CONFIG)
+        env = Environment(path, _agents, CONFIG, env_vars=env_vars)
         env.run_task(task, record_run, load_env, max_iterations)
 
     def run_remote(

--- a/nearai/environment.py
+++ b/nearai/environment.py
@@ -35,7 +35,12 @@ TERMINAL_FILENAME = "terminal.txt"
 
 class Environment(object):
     def __init__(  # noqa: D107
-        self, path: str, agents: List[Agent], config: Config, create_files: bool = True
+        self,
+        path: str,
+        agents: List[Agent],
+        config: Config,
+        create_files: bool = True,
+        env_vars: Optional[Dict[str, Any]] = None,
     ) -> None:
         self._path = path
         self._agents = agents
@@ -45,6 +50,7 @@ class Environment(object):
         self._user_name = config.user_name
         self._tools = ToolRegistry()
         self.register_standard_tools()
+        self.env_vars: Dict[str, Any] = env_vars if env_vars else {}
 
         if self._config.nearai_hub is None:
             self._config.nearai_hub = NearAiHubConfig()


### PR DESCRIPTION
How to test:
1) nearai agent interactive zavodil.near/test-env-agent/1 --local This loads env_vars from metadata

2) nearai agent interactive zavodil.near/test-env-agent/1 --local --env_vars='{"id":"new-value"}' This loads env_vars from metadata and partially overwrites with env_vars from command line

fix: error prompt if `agent.py` is missing in the agent folder