### PR TITLE
Add cname file

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.near.ai


### PR DESCRIPTION
After compiling the docs with `mkdocs`, it doesn't add a `CNAME` file. Adding manually to the docs dir.