### PR TITLE
Updates to metadata template

### DIFF
--- a/docs/agent_quickstart.sh
+++ b/docs/agent_quickstart.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 . .venv/bin/activate # if your virtual environment is elsewhere, change this line
 mkdir -p ~/.nearai/registry/example_agent
-nearai registry metadata_template ~/.nearai/registry/example_agent
+nearai registry metadata_template ~/.nearai/registry/example_agent agent "Example agent"
 cat docs/example_agent.py.txt > ~/.nearai/registry/example_agent/agent.py
 open ~/.nearai/registry/example_agent/metadata.json
 open ~/.nearai/registry/example_agent/agent.py

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -14,7 +14,7 @@ docs/agent_quickstart.sh
 
 3. Create a metadata.json file for your agent
 
-   `nearai registry metadata_template ~/.nearai/registry/example_agent` and edit it.
+   `nearai registry metadata_template ~/.nearai/registry/example_agent agent "Example agent"` and edit it.
 
 4. Create an `agent.py` file in that folder.
      * Write your agent, in agent.py, using the [environment API](#the-environment-api) described below.

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ dataset it may be hundreds of files.
 
 The metadata_template command will create a template for you to fill in.
 ```
-nearai registry metadata_template <ITEM_LOCAL_DIRECTORY_PATH>
+nearai registry metadata_template <ITEM_LOCAL_DIRECTORY_PATH> <CATEGORY> <DESCRIPTION>
 ```
 Fill in name, version, category and any other fields for which you have values.
 The current categories are: `model`, `dataset`, `agent`, `environment`.

--- a/nearai/cli.py
+++ b/nearai/cli.py
@@ -48,20 +48,23 @@ class RegistryCli:
 
         print(metadata.model_dump_json(indent=2))
 
-    def metadata_template(self, local_path: str = "."):
+    def metadata_template(self, local_path: str = ".", category: str = "", description: str = ""):
         """Create a metadata template."""
         path = Path(local_path)
 
         metadata_path = path / "metadata.json"
 
+        # Get the name of the folder
+        folder_name = path.name
+
         with open(metadata_path, "w") as f:
             json.dump(
                 {
-                    "name": "foobar",
+                    "name": folder_name,
                     "version": "0.0.1",
-                    "description": "Template metadata",
-                    "category": "model",
-                    "tags": ["foo", "bar"],
+                    "description": description,
+                    "category": category,
+                    "tags": [],
                     "details": {},
                     "show_entry": True,
                 },


### PR DESCRIPTION
Was:
```
$ nearai registry metadata_template ~/.nearai/registry/example_agent
$ cat ~/.nearai/registry/example_agent/metadata.json
{
  "name": "foobar",
  "version": "0.0.1",
  "description": "Template metadata",
  "category": "model",
  "tags": [
    "foo",
    "bar"
  ],
  "details": {},
  "show_entry": true
}
```

Now:
```
$ nearai registry metadata_template ~/.nearai/registry/example_agent agent "Example agent"
$ cat ~/.nearai/registry/example_agent/metadata.json
{
  "name": "example_agent",
  "version": "0.0.1",
  "description": "Example agent",
  "category": "agent",
  "tags": [],
  "details": {},
  "show_entry": true
}
```
