### PR TITLE
Update ruff extend-exclude rule in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ exclude = [
     "venv",
     "openapi_client",
 ]
-extend-exclude = ["tests", "projects", "examples"]
+extend-exclude = ["./*/tests", "./*/projects", "./*/examples"]
 line-length = 120
 indent-width = 4
 


### PR DESCRIPTION
Fixe the problem of VS Code ignoring lint of all nearai project if the whole nearai project is placed under one of 'extend-exclude' directories.

Fixes #217