### PR TITLE
Fix nonce list display

### DIFF
--- a/hub/demo/src/app/settings/NonceList.tsx
+++ b/hub/demo/src/app/settings/NonceList.tsx
@@ -134,7 +134,7 @@ export const NonceList = () => {
           {nonces.data?.map((nonce) => (
             <Table.Row key={nonce.nonce}>
               <Table.Cell>
-                <Text size="text-xs" color="sand-12" clampLines={1}>
+                <Text size="text-xs" color="sand-12">
                   {nonce.nonce}
                 </Text>
               </Table.Cell>

--- a/hub/demo/src/components/lib/Text.tsx
+++ b/hub/demo/src/components/lib/Text.tsx
@@ -25,6 +25,7 @@ type Props = {
   className?: string;
   color?: ThemeColor;
   decoration?: CSSProperties['textDecoration'];
+  forceWordBreak?: boolean;
   id?: string;
   size?: ThemeFontSize;
   sizePhone?: ThemeFontSize;
@@ -41,6 +42,7 @@ export const Text = ({
   className = '',
   color,
   decoration,
+  forceWordBreak,
   size,
   style,
   weight,
@@ -65,6 +67,7 @@ export const Text = ({
         fontWeight: weight,
         WebkitLineClamp: clampLines,
         whiteSpace: noWrap ? 'nowrap' : undefined,
+        wordBreak: forceWordBreak ? 'break-word' : undefined,
         ...style,
       }}
       {...props}


### PR DESCRIPTION
The nonce was previously being truncated in the table display. This PR fixes that and adds the ability to pass `forceWordBreak` as a prop to `Text`.