### PR TITLE
Extract namespace from path. Check for similar names before creating a new registry item

### DIFF
--- a/nearai/naming.py
+++ b/nearai/naming.py
@@ -1,0 +1,33 @@
+import re
+
+
+def get_canonical_name(name: str) -> str:
+    """Returns a name that can be used for matching entities.
+
+    Applies such transformations:
+    1. All letters lowercase.
+    2. Convert '.' between digits to 'p'.
+    3. Convert '<not letter>v<digit>' -> '<not letter><digit>'
+    4. Remove all non-alphanumeric characters except between digits.
+        Use '_' between digits.
+    5. Convert 'metallama' -> 'llama'.
+
+    e.g. "llama-3.1-70b-instruct" -> "llama3p1_70binstruct"
+    """
+    # Convert to lowercase
+    name = name.lower()
+    # Convert '.' between digits to 'p'
+    name = re.sub(r"(\d)\.(\d)", r"\1p\2", name)
+    # Convert '<digit>v<digit>' -> '<digit>_<digit>'
+    name = re.sub(r"(\d)v(\d)", r"\1_\2", name)
+    # Convert '<not letter>v<digit>' -> '<not letter><digit>'
+    name = re.sub(r"(^|[^a-z])v(\d)", r"\1\2", name)
+    # Replace non-alphanumeric characters between digits with '_'
+    name = re.sub(r"(\d)[^a-z0-9]+(\d)", r"\1_\2", name)
+    # Remove remaining non-alphanumeric characters, except '_'
+    name = re.sub(r"[^a-z0-9_]", "", name)
+    # Remove any remaining underscores that are not between digits
+    name = re.sub(r"(?<!\d)_|_(?!\d)", "", name)
+    # Convert 'metallama' to 'llama'
+    name = name.replace("metallama", "llama")
+    return name

--- a/nearai/registry.py
+++ b/nearai/registry.py
@@ -19,6 +19,7 @@ from tqdm import tqdm
 #       API client that is used by Registry API.
 from nearai.config import CONFIG, DATA_FOLDER
 from nearai.lib import check_metadata, parse_location
+from nearai.naming import get_canonical_name
 
 REGISTRY_FOLDER = "registry"
 
@@ -26,6 +27,29 @@ REGISTRY_FOLDER = "registry"
 def get_registry_folder() -> Path:
     """Path to local registry."""
     return DATA_FOLDER / REGISTRY_FOLDER
+
+
+def get_namespace(local_path: Path) -> str:
+    """Returns namespace of an item or user namespace."""
+    registry_folder = get_registry_folder()
+
+    try:
+        # Check if the path matches the expected structure
+        relative_path = local_path.relative_to(registry_folder)
+        parts = relative_path.parts
+
+        # If the path has 3 parts (namespace, item_name, version),
+        # return the first part as the namespace
+        if len(parts) == 3:
+            return str(parts[0])
+    except ValueError:
+        # relative_to() raises ValueError if local_path is not relative to registry_folder
+        pass
+
+    # If we couldn't extract a namespace from the path, return the default
+    if CONFIG.auth is None:
+        raise ValueError("AuthData is None")
+    return CONFIG.auth.account_id
 
 
 class Registry:
@@ -161,12 +185,13 @@ class Registry:
         with open(metadata_path) as f:
             plain_metadata: Dict[str, Any] = json.load(f)
 
-        namespace = CONFIG.auth.account_id
+        namespace = get_namespace(local_path)
+        name = plain_metadata.pop("name")
 
         entry_location = EntryLocation.model_validate(
             dict(
                 namespace=namespace,
-                name=plain_metadata.pop("name"),
+                name=name,
                 version=plain_metadata.pop("version"),
             )
         )
@@ -177,6 +202,20 @@ class Registry:
         if source is not None:
             print(f"Only default source is allowed, found: {source}. Remove details._source from metadata.")
             exit(1)
+
+        if self.info(entry_location) is None:
+            # New entry location. Check for similar names in registry.
+            entries = self.list_all_visible()
+            canonical_namespace = get_canonical_name(namespace)
+            canonical_name = get_canonical_name(name)
+
+            for entry in entries:
+                if (
+                    get_canonical_name(entry.name) == canonical_name
+                    and get_canonical_name(entry.namespace) == canonical_namespace
+                ):
+                    print(f"A registry item with a similar name already exists: {entry.namespace}/{entry.name}")
+                    exit(1)
 
         registry.update(entry_location, entry_metadata)
 
@@ -244,6 +283,13 @@ class Registry:
             show_hidden=show_all,
             show_latest_version=show_latest_version,
         )
+
+    def list_all_visible(self) -> List[EntryInformation]:
+        """List all visible entries."""
+        total = 10000
+        entries = self.list("", "", "", total, 0, False, True)
+        assert len(entries) < total
+        return entries
 
 
 registry = Registry()

--- a/nearai/tests/test_naming.py
+++ b/nearai/tests/test_naming.py
@@ -1,0 +1,60 @@
+import unittest
+
+from nearai.naming import get_canonical_name
+
+
+class TestGetCanonicalName(unittest.TestCase):
+    """Unit tests for get_canonical_name"""
+
+    def test_lowercase_conversion(self):
+        self.assertEqual(get_canonical_name("LLaMA"), "llama")
+
+    def test_dot_to_p_conversion(self):
+        self.assertEqual(get_canonical_name("model1.5"), "model1p5")
+
+    def test_space_between_digits(self):
+        self.assertEqual(get_canonical_name("3.1-70b"), "3p1_70b")
+        self.assertEqual(get_canonical_name("3.1_70b"), "3p1_70b")
+        self.assertEqual(get_canonical_name("3.1- -70b"), "3p1_70b")
+
+    def test_remove_non_alphanumeric(self):
+        self.assertEqual(get_canonical_name("llama-3.1-70b-instruct"), "llama3p1_70binstruct")
+
+    def test_underscores(self):
+        self.assertEqual(get_canonical_name("_"), "")
+        self.assertEqual(get_canonical_name("a_"), "a")
+        self.assertEqual(get_canonical_name("1_"), "1")
+        self.assertEqual(get_canonical_name("_a"), "a")
+        self.assertEqual(get_canonical_name("_1"), "1")
+        self.assertEqual(get_canonical_name("a_a"), "aa")
+        self.assertEqual(get_canonical_name("a_1"), "a1")
+        self.assertEqual(get_canonical_name("1_a"), "1a")
+        self.assertEqual(get_canonical_name("1_1"), "1_1")
+
+        self.assertEqual(get_canonical_name("__"), "")
+        self.assertEqual(get_canonical_name("a__"), "a")
+        self.assertEqual(get_canonical_name("1__"), "1")
+        self.assertEqual(get_canonical_name("__a"), "a")
+        self.assertEqual(get_canonical_name("__1"), "1")
+        self.assertEqual(get_canonical_name("a__a"), "aa")
+        self.assertEqual(get_canonical_name("a__1"), "a1")
+        self.assertEqual(get_canonical_name("1__a"), "1a")
+        self.assertEqual(get_canonical_name("1__1"), "1_1")
+
+    def test_metallama_conversion(self):
+        self.assertEqual(get_canonical_name("metallama-3b"), "llama3b")
+
+    def test_v_digit_conversion(self):
+        self.assertEqual(get_canonical_name("llama-v2-7b"), "llama2_7b")
+        self.assertEqual(get_canonical_name("gpt-v4"), "gpt4")
+        self.assertEqual(get_canonical_name("v4"), "4")
+        self.assertEqual(get_canonical_name("3v4"), "3_4")
+        self.assertEqual(get_canonical_name("3 v4"), "3_4")
+        self.assertEqual(get_canonical_name("mev4"), "mev4")
+
+    def test_meta_llama_3p1_405b_instruct_match(self):
+        self.assertEqual(get_canonical_name("Meta-Llama-3.1-405B-Instruct"), get_canonical_name("llama-v3p1-405b-instruct"))
+        self.assertEqual(get_canonical_name("llama-3.1-405b-instruct"), get_canonical_name("llama-v3p1-405b-instruct"))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
2 key changes:
1. It brings ability to modify a registry item under different namespace.
2. It now checks for similar "namespace/name" registry items

```
[1] nearai registry upload ~/.nearai/registry/alomonos.near/example-agent/0.0.2
A registry item with a similar name already exists: alomonos.near/example_agent
```

Related #228