### PR TITLE
Run aws_runner deployment script and local Docker testing from root 

### DIFF
--- a/aws_runner/Dockerfile
+++ b/aws_runner/Dockerfile
@@ -3,13 +3,13 @@ FROM public.ecr.aws/lambda/python:3.12
 # pass with --build-arg FRAMEWORK=-langgraph
 ARG FRAMEWORK=""
 
-COPY frameworks/requirements${FRAMEWORK}.txt ${LAMBDA_TASK_ROOT}
+COPY aws_runner/frameworks/requirements${FRAMEWORK}.txt ${LAMBDA_TASK_ROOT}
 
 RUN pip install -r requirements${FRAMEWORK}.txt
 
 # Runner code
-COPY service.py partial_near_client.py ${LAMBDA_TASK_ROOT}
-COPY runner ${LAMBDA_TASK_ROOT}/runner
+COPY aws_runner/service.py aws_runner/partial_near_client.py ${LAMBDA_TASK_ROOT}
+COPY aws_runner/runner ${LAMBDA_TASK_ROOT}/runner
 COPY openapi_client ${LAMBDA_TASK_ROOT}/openapi_client
 
 CMD [ "service.handler" ]

--- a/aws_runner/README.md
+++ b/aws_runner/README.md
@@ -6,11 +6,18 @@ to fetch agent code, and to fetch and store environments (store not implemented 
 
 
 ## Local testing
-`docker build --platform linux/amd64 --build-arg FRAMEWORK=-base -t nearai-runner:test .`
+__Docker must be run from the root of the repository so the Dockerfile can pull in openapi_client.__
 
-`docker run --platform linux/amd64 -p 9000:8080 nearai-runner:test`
+Note the dash before the framework names and after the environment names.
 
-This will start the server on port 9000. To call the server you will need a signedMessage for the auth param.
+Base framework `docker build -f aws_runner/Dockerfile --platform linux/amd64 --build-arg -t nearai-runner:test .`
+
+LangGraph framework `docker build -f aws_runner/Dockerfile --platform linux/amd64 --build-arg FRAMEWORK=-langgraph -t nearai-runner:test .`
+
+`docker run --platform linux/amd64 -p 9000:8080 nearai-runner:test` will start the server on port 9000. 
+
+To call the server you will need a signedMessage for the auth param.
+
 ```
 curl "http://localhost:9000/2015-03-31/functions/function/invocations" \
 -d @- <<'EOF'

--- a/aws_runner/deploy.sh
+++ b/aws_runner/deploy.sh
@@ -1,5 +1,16 @@
 #!/bin/sh
 
+## Deploy script for AWS Lambda Agent runner
+## This script must be run from the root of the repository so the Docker build can pull in openapi_client.
+##
+## Usage: aws_runner/deploy.sh [all]
+##    FRAMEWORK=base|langgraph ENV=staging|production aws_runner/deploy.sh
+## Examples:
+##    aws_runner/deploy.sh all
+##    FRAMEWORK=base ENV=staging aws_runner/deploy.sh
+##
+## Builds the Docker image, pushes it to ECR, and updates the Lambda function to use it.
+
 ALL_FRAMEWORKS=("base" "langgraph")
 ALL_ENVIRONMENTS=("staging" "production")
 
@@ -10,7 +21,7 @@ deploy() {
   echo "Deploying ${ENV}agent-runner${FRAMEWORK}"
 
   aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin 543900120763.dkr.ecr.us-east-2.amazonaws.com
-  docker build --platform linux/amd64 --build-arg FRAMEWORK=${FRAMEWORK} -t nearai-runner${FRAMEWORK} .
+  docker build -f aws_runner/Dockerfile --platform linux/amd64 --build-arg FRAMEWORK=${FRAMEWORK} -t nearai-runner${FRAMEWORK} .
   docker tag nearai-runner${FRAMEWORK}:latest 543900120763.dkr.ecr.us-east-2.amazonaws.com/nearai-runner${FRAMEWORK}:latest
   docker push 543900120763.dkr.ecr.us-east-2.amazonaws.com/nearai-runner${FRAMEWORK}:latest
   aws lambda update-function-code --region us-east-2 \

--- a/aws_runner/service.py
+++ b/aws_runner/service.py
@@ -50,20 +50,22 @@ def handler(event, context):
 
 
 def write_metric(metric_name, value, unit="Milliseconds"):
-    cloudwatch.put_metric_data(
-        Namespace="NearAI",
-        MetricData=[
-            {
-                "MetricName": metric_name,
-                "Value": value,
-                "Unit": unit,
-                "Dimensions": [
-                    {"Name": "FunctionName", "Value": FUNCTION_NAME},
-                ],
-            }
-        ],
-    )
-
+    if os.environ.get("AWS_ACCESS_KEY_ID"): # running in lambda or locally passed credentials
+        cloudwatch.put_metric_data(
+            Namespace="NearAI",
+            MetricData=[
+                {
+                    "MetricName": metric_name,
+                    "Value": value,
+                    "Unit": unit,
+                    "Dimensions": [
+                        {"Name": "FunctionName", "Value": FUNCTION_NAME},
+                    ],
+                }
+            ],
+        )
+    else:
+        print(f"Would have written metric {metric_name} with value {value} to cloudwatch")
 
 def load_agent(client, agent, agent_env_vars):
     env_vars = agent_env_vars.get(agent, {})


### PR DESCRIPTION
of repository to pick up top level openapi_client.

Also makes AWS credentials optional when running the aws_runner locally in Docker.