### PR TITLE
feat: local runner reset conversation

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -25,6 +25,11 @@ docs/agent_quickstart.sh
 nearai agent interactive example_agent /tmp/example_agent_run_1 --local
 ```
 
+When running the agent locally, session files such as chat history are stored in the `/tmp/nearai/conversations/` folder. 
+If you want to reset these files and clear the conversation history, you can run the agent with the `--reset` flag. 
+This will remove the existing session data and start a new one.
+
+
 ### Example agent.py
 ```python
 # In local interactive mode, the first user input is collected before the agent runs.

--- a/nearai/agents/local_runner.py
+++ b/nearai/agents/local_runner.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import tarfile
 import tempfile
 from pathlib import Path
@@ -27,6 +28,7 @@ class LocalRunner:
         tool_resources=None,
         print_system_log=True,
         confirm_commands=True,
+        reset=False,
     ) -> None:
         if path:
             self._path = path
@@ -39,6 +41,9 @@ class LocalRunner:
         self._confirm_commands = confirm_commands
 
         client = InferenceClient(client_config)
+
+        if reset:
+            shutil.rmtree(self._path)
 
         self._env = Environment(
             self._path,

--- a/nearai/cli.py
+++ b/nearai/cli.py
@@ -427,6 +427,7 @@ class AgentCli:
         local: bool = False,
         tool_resources: Optional[Dict[str, Any]] = None,
         print_system_log: bool = True,
+        reset: bool = False,
     ) -> None:
         """Runs agent interactively with environment from given path."""
         from nearai.agents.local_runner import LocalRunner
@@ -442,6 +443,7 @@ class AgentCli:
             env_vars=env_vars,
             tool_resources=tool_resources,
             print_system_log=print_system_log,
+            reset=reset,
             confirm_commands=CONFIG.get("confirm_commands", True),
         )
         runner.run_interactive(record_run, load_env)


### PR DESCRIPTION
When running the agent locally, session files such as chat history are stored in the `/tmp/nearai/conversations/ folder`.
If you want to reset these files and clear the conversation history, you can run the agent with the `--reset` flag.
This will remove the existing session data and start a new one.