### PR TITLE
Execute environment commands in shell

### DIFF
--- a/nearai/agents/environment.py
+++ b/nearai/agents/environment.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import re
-import shlex
 import shutil
 import subprocess
 import tarfile
@@ -328,9 +327,10 @@ class Environment(object):
 
         try:
             process = subprocess.Popen(
-                shlex.split(command),
+                command,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                shell=True,
                 bufsize=0,
                 universal_newlines=True,
                 cwd=self._path,


### PR DESCRIPTION
Before this change:
Command `command=test_dir && touch test_dir/hello.txt` creates `hello.txt` as directory.
After this change:
Command `command=test_dir && touch test_dir/hello.txt` works correctly, creating an empty file.