### PR TITLE
feat: iframe to allow popups

### DIFF
--- a/hub/demo/src/components/lib/IframeWithBlob.tsx
+++ b/hub/demo/src/components/lib/IframeWithBlob.tsx
@@ -96,7 +96,7 @@ export const IframeWithBlob = ({
         height={height}
         ref={iframeRef}
         src={dataUrl}
-        sandbox="allow-scripts"
+        sandbox="allow-scripts allow-popups"
         className={`${s.visibleIframe} ${className}`}
         data-loading={height < 10}
         {...props}


### PR DESCRIPTION
A hotfix PR to allow the agent's HTML to use links with `target="_blank"`

This allows the agent to open links in new tabs. However, I doubt there is any significant benefit for bad actors to exploit this feature.