### PR TITLE
Add Last Updated column to registry tables

### DIFF
--- a/hub/.env.example
+++ b/hub/.env.example
@@ -1,4 +1,4 @@
-RUNNER_ENVIRONMENT=local
+RUNNER_ENVIRONMENT=local_runner
 # API_URL=https://MY-OWN.ngrok.io # this allows running a remote agent against a custom api (local with ngrok for instance)
 DATABASE_HOST=localhost
 DATABASE_USER=root

--- a/hub/api/v1/registry.py
+++ b/hub/api/v1/registry.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import re
@@ -281,6 +282,7 @@ class EntryInformation(BaseModel):
     namespace: str
     name: str
     version: str
+    updated: datetime.datetime
     category: str
     description: str
     details: Dict[str, Any]
@@ -365,7 +367,7 @@ def list_entries(
                 GROUP BY namespace, name
             )
             SELECT registry.id, registry.namespace, registry.name, registry.version,
-            registry.category, registry.description, registry.details,
+            registry.category, registry.description, registry.details, registry.time,
             CountedStars.num_stars, CountedStars.starred_by_pov
             FROM registry_entry registry
             LEFT JOIN CountedStars
@@ -415,7 +417,7 @@ def list_entries(
                     )
 
                     SELECT registry.id, registry.namespace, registry.name, registry.version,
-                           registry.category, registry.description, registry.details,
+                           registry.category, registry.description, registry.details, registry.time,
                            ranked.num_stars, ranked.starred_by_pov
                     FROM RankedRegistry ranked
                     JOIN registry_entry registry ON ranked.id = registry.id
@@ -429,7 +431,7 @@ def list_entries(
             bind_params["tags"] = tags_list
             bind_params["ntags"] = len(tags_list)
 
-        for id, namespace_, name, version, category_, description, details, num_stars, pov in session.exec(
+        for id, namespace_, name, version, category_, description, details, timestamp, num_stars, pov in session.exec(
             text(query_text).bindparams(**bind_params)
         ).all():  # type: ignore
             print(namespace_, name, version, num_stars)
@@ -439,6 +441,7 @@ def list_entries(
                     namespace=namespace_,
                     name=name,
                     version=version,
+                    updated=timestamp.replace(tzinfo=datetime.timezone.utc),
                     category=category_,
                     description=description,
                     details=json.loads(details),

--- a/hub/demo/src/components/EntriesTable.tsx
+++ b/hub/demo/src/components/EntriesTable.tsx
@@ -24,6 +24,7 @@ import { type EntryCategory } from '~/lib/models';
 import { api } from '~/trpc/react';
 
 import { StarButton } from './StarButton';
+import { format, formatDistanceToNow } from 'date-fns';
 
 type Props = {
   category: EntryCategory;
@@ -85,6 +86,9 @@ export const EntriesTable = ({ category, title }: Props) => {
               Creator
             </Table.HeadCell>
             <Table.HeadCell>Version</Table.HeadCell>
+            <Table.HeadCell column="updated" sortable>
+              Updated
+            </Table.HeadCell>
             <Table.HeadCell>Tags</Table.HeadCell>
             <Table.HeadCell
               column="num_stars"
@@ -131,6 +135,14 @@ export const EntriesTable = ({ category, title }: Props) => {
 
               <Table.Cell>
                 <Text size="text-s">{entry.version}</Text>
+              </Table.Cell>
+
+              <Table.Cell>
+                <Text size="text-s">
+                  <Tooltip content={format(entry.updated, 'PPpp')}>
+                    <span>{formatDistanceToNow(entry.updated, { addSuffix: true })}</span>
+                  </Tooltip>
+                </Text>
               </Table.Cell>
 
               <Table.Cell style={{ maxWidth: '14rem', overflow: 'hidden' }}>

--- a/hub/demo/src/lib/models.ts
+++ b/hub/demo/src/lib/models.ts
@@ -143,6 +143,7 @@ export const entryModel = z.object({
   namespace: z.string(),
   name: z.string(),
   version: z.string(),
+  updated: z.string().datetime(),
   description: z.string().default(''),
   tags: z.string().array().default([]),
   show_entry: z.boolean().default(true),


### PR DESCRIPTION
I'd like to see the most recent agents and datasets on the interface, so this change adds an 'Updated' column.