### PR TITLE
Remove instructions and model from `/threads/${thread.id}/runs` call

### DIFF
--- a/hub/demo/src/server/utils/threads.ts
+++ b/hub/demo/src/server/utils/threads.ts
@@ -83,8 +83,6 @@ export async function runMessageOnAgentThread(
       body: JSON.stringify({
         thread_id: thread.id,
         assistant_id: input.agent_id,
-        instructions: 'You are a helpful assistant. Complete the given task.',
-        model: 'fireworks::accounts/fireworks/models/qwen2p5-72b-instruct',
       }),
     },
   );


### PR DESCRIPTION
Similar to `cli.py` changes in https://github.com/nearai/nearai/pull/492 we shouldn't pass `instructions` and `model` to a thread run in frontend.

Related: we have not yet implemented passing a model to an agent run (#233)