### PR TITLE
Use one DB connection per auth verification.

### DIFF
--- a/hub/api/v1/auth.py
+++ b/hub/api/v1/auth.py
@@ -14,7 +14,6 @@ from hub.api.v1.sql import SqlClient
 
 bearer = HTTPBearer(auto_error=False)
 logger = logging.getLogger(__name__)
-db = SqlClient()
 
 
 class AuthToken(BaseModel):
@@ -58,7 +57,7 @@ class RawAuthToken(AuthToken):
         )
 
 
-async def parse_auth(token: Optional[HTTPAuthorizationCredentials] = Depends(bearer)):
+def parse_auth(token: Optional[HTTPAuthorizationCredentials] = Depends(bearer)):
     if token is None:
         return None
 
@@ -74,7 +73,7 @@ async def parse_auth(token: Optional[HTTPAuthorizationCredentials] = Depends(bea
         raise TokenValidationError(detail=str(e)) from None
 
 
-async def validate_signature(auth: Optional[RawAuthToken] = Depends(parse_auth)):
+def validate_signature(auth: Optional[RawAuthToken] = Depends(parse_auth)):
     if auth is None:
         return None
 
@@ -121,12 +120,13 @@ async def validate_signature(auth: Optional[RawAuthToken] = Depends(parse_auth))
     return auth.unwrap()
 
 
-async def revokable_auth(auth: Optional[AuthToken] = Depends(validate_signature)):
+def revokable_auth(auth: Optional[AuthToken] = Depends(validate_signature)):
     if auth is None:
         return None
 
     logger.debug(f"Validating auth token: {auth}")
 
+    db = SqlClient()  # TODO(https://github.com/nearai/nearai/issues/545): Use SQLAlchemy
     user_nonce = db.get_account_nonce(auth.account_id, auth.nonce)
 
     if user_nonce and user_nonce.is_revoked():
@@ -139,7 +139,7 @@ async def revokable_auth(auth: Optional[AuthToken] = Depends(validate_signature)
     return auth
 
 
-async def get_optional_auth(auth: Optional[AuthToken] = Depends(revokable_auth)):
+def get_optional_auth(auth: Optional[AuthToken] = Depends(revokable_auth)):
     """Returns the validated auth token in case it was provided, otherwise returns None."""
     # This method is the last layer of the middleware the builds the auth token, it
     # should be used instead of any previous method in the chain (e.g. `revokable_auth`).
@@ -149,7 +149,7 @@ async def get_optional_auth(auth: Optional[AuthToken] = Depends(revokable_auth))
     return auth
 
 
-async def get_auth(auth: Optional[AuthToken] = Depends(get_optional_auth)):
+def get_auth(auth: Optional[AuthToken] = Depends(get_optional_auth)):
     if auth is None:
         raise HTTPException(status_code=403, detail="Authorization required")
     return auth


### PR DESCRIPTION
Remove async, slows down the whole runtime since these functions are not async.

Use a new DB connection per auth verification.