### PR TITLE
Small changes to the competition copy

### DIFF
--- a/hub/demo/src/app/competitions/0.5b-november-2024/page.tsx
+++ b/hub/demo/src/app/competitions/0.5b-november-2024/page.tsx
@@ -16,8 +16,6 @@ To participate, you will need \`nearai-cli\` installed on your computer. For det
 From your machine you will use \`nearai-cli submit\` to submit your runs. From within the run, you will use \`near-cli\` to download raw data and to upload datasets and pre-trained models, as well as to run evaluations.
 
 To participate in the competition, apply [here](https://docs.google.com/forms/d/e/1FAIpQLScInS4mHyZb_kSkD0-CMPPagyhpBKdutbAyS6YNbHJc9ZgaUw/viewform).
-
-Whenever you run a LiveBench benchmark from a run initiated with \`nearai-cli submit\`, the result will appear on the leaderboard.
 `;
   return (
     <CompetitionPage title="0.5B Model Training Competition - November 2024">

--- a/hub/demo/src/app/competitions/0.5b-november-2024/page.tsx
+++ b/hub/demo/src/app/competitions/0.5b-november-2024/page.tsx
@@ -11,9 +11,9 @@ In this competition, we want the participants to pre-train a 0.5B parameter mode
 
 0.5B parameter model is quite small in the model world, but it can be trained relatively quickly, and thus allows iterating over various ideas and techniques. We will host more competition for large models, and scaling laws, in the new future. Learn more about this strategy [on the NEAR AI blog](https://near.ai).
 
-To participate, you will need \`nearai-cli\` installed on your computer. For details and documentation, visit the [nearai-cli GitHub page](https://github.com/nearai/nearai).
+To participate, you will need \`nearai\` installed on your computer. For details and documentation, visit the [nearai GitHub page](https://github.com/nearai/nearai).
 
-From your machine you will use \`nearai-cli submit\` to submit your runs. From within the run, you will use \`near-cli\` to download raw data and to upload datasets and pre-trained models, as well as to run evaluations.
+From your machine you will use \`nearai submit\` to submit your runs. From within the run, you will use \`nearai\` to download raw data and to upload datasets and pre-trained models, as well as to run evaluations.
 
 To participate in the competition, apply [here](https://docs.google.com/forms/d/e/1FAIpQLScInS4mHyZb_kSkD0-CMPPagyhpBKdutbAyS6YNbHJc9ZgaUw/viewform).
 `;

--- a/hub/demo/src/app/competitions/0.5b-november-2024/page.tsx
+++ b/hub/demo/src/app/competitions/0.5b-november-2024/page.tsx
@@ -7,13 +7,15 @@ export default function ModelTrainingPage() {
   const content = `
 Welcome to the first NEAR AI competition.
 
-In this competition, we want the participants to pre-train a 0.5B parameter model that performs as well as possible on a versatile benchmark called [LiveBench](https://livebench.ai/).
+In this competition, we want the participants to pre-train a 0.5B parameter model that has the lowest perplexity as measured on a hold-out subset of FineWeb.
 
 0.5B parameter model is quite small in the model world, but it can be trained relatively quickly, and thus allows iterating over various ideas and techniques. We will host more competition for large models, and scaling laws, in the new future. Learn more about this strategy [on the NEAR AI blog](https://near.ai).
 
 To participate, you will need \`nearai-cli\` installed on your computer. For details and documentation, visit the [nearai-cli GitHub page](https://github.com/nearai/nearai).
 
 From your machine you will use \`nearai-cli submit\` to submit your runs. From within the run, you will use \`near-cli\` to download raw data and to upload datasets and pre-trained models, as well as to run evaluations.
+
+To participate in the competition, apply [here](https://docs.google.com/forms/d/e/1FAIpQLScInS4mHyZb_kSkD0-CMPPagyhpBKdutbAyS6YNbHJc9ZgaUw/viewform).
 
 Whenever you run a LiveBench benchmark from a run initiated with \`nearai-cli submit\`, the result will appear on the leaderboard.
 `;


### PR DESCRIPTION
Added the link to the form, and replaced mention of livebench with perplexity