### PR TITLE
Use default benchmark columns on leaderboard

### DIFF
--- a/hub/demo/src/app/competitions/[competition]/CompetitionPage.tsx
+++ b/hub/demo/src/app/competitions/[competition]/CompetitionPage.tsx
@@ -36,7 +36,6 @@ const CompetitionPage = ({
       <Section>
         <EvaluationsTable
           title="Leaderboard"
-          benchmarkColumns={['live_bench/average']}
           showSidebar={false}
           onlyShowEvaluationsWithMatchingBenchmark
         />


### PR DESCRIPTION
The UI for competition leaderboard benchmarks will now show the columns in `important_columns` instead of hardcoding to `live_bench/average`