### PR TITLE
Add "show logs" toggle to agent runner UI

### DIFF
--- a/hub/demo/package-lock.json
+++ b/hub/demo/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@gera2ld/tarjs": "^0.3.1",
         "@hookform/resolvers": "^3.6.0",
-        "@near-pagoda/ui": "^2.0.14",
+        "@near-pagoda/ui": "^2.0.17",
         "@near-wallet-selector/bitte-wallet": "8.9.14",
         "@near-wallet-selector/core": "8.9.14",
         "@near-wallet-selector/here-wallet": "8.9.14",
@@ -827,9 +827,9 @@
       }
     },
     "node_modules/@near-pagoda/ui": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@near-pagoda/ui/-/ui-2.0.14.tgz",
-      "integrity": "sha512-GMnZArZTGKBg30Ge4gPKPELGFFR9mahn6LZmlkX+1T+UJ1zEZ8q8LiSVr+fF63Pfa2CcmpUSE0q07ykEkaLSUQ==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@near-pagoda/ui/-/ui-2.0.17.tgz",
+      "integrity": "sha512-f2YLHNLkwNcKXrVUDhzdHbl74hygYP6ax6K2/pjsgpcPMSlgwhNy4klyAgj815ixC4ynwLA8nNWmMLi7F7rPCQ==",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.5",
         "@radix-ui/colors": "^3.0.0",

--- a/hub/demo/package.json
+++ b/hub/demo/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@gera2ld/tarjs": "^0.3.1",
     "@hookform/resolvers": "^3.6.0",
-    "@near-pagoda/ui": "^2.0.14",
+    "@near-pagoda/ui": "^2.0.17",
     "@near-wallet-selector/bitte-wallet": "8.9.14",
     "@near-wallet-selector/core": "8.9.14",
     "@near-wallet-selector/here-wallet": "8.9.14",

--- a/hub/demo/src/components/AgentRunner.tsx
+++ b/hub/demo/src/components/AgentRunner.tsx
@@ -15,7 +15,15 @@ import {
   Text,
   Tooltip,
 } from '@near-pagoda/ui';
-import { ArrowRight, Chats, Eye, Gear, List } from '@phosphor-icons/react';
+import {
+  ArrowRight,
+  Chats,
+  Eye,
+  Folder,
+  Gear,
+  Info,
+  List,
+} from '@phosphor-icons/react';
 import { useMutation } from '@tanstack/react-query';
 import {
   type KeyboardEventHandler,
@@ -83,6 +91,7 @@ export const AgentRunner = ({
 
   const isAuthenticated = useAuthStore((store) => store.isAuthenticated);
   const { queryParams, updateQueryPath } = useQueryParams([
+    'showLogs',
     'threadId',
     'view',
     'transactionHashes',
@@ -94,6 +103,7 @@ export const AgentRunner = ({
   );
   const utils = api.useUtils();
   const threadId = queryParams.threadId ?? '';
+  const showLogs = queryParams.showLogs === 'true';
 
   const form = useForm<FormSchema>({
     defaultValues: {
@@ -169,30 +179,40 @@ export const AgentRunner = ({
     },
   });
 
+  const logMessages = useMemo(() => {
+    const result = (thread ? Object.values(thread.messagesById) : []).filter(
+      (message) => message.metadata?.message_type?.startsWith('system:'),
+    );
+    return result;
+  }, [thread]);
+
   const messages = useMemo(() => {
     const result = [
       ...(thread ? Object.values(thread.messagesById) : []),
       ...optimisticMessages.map((message) => message.data),
     ].filter(
-      (message) => message.metadata?.message_type !== 'system:file_write',
+      (message) =>
+        showLogs || !message.metadata?.message_type?.startsWith('system:'),
     );
     return result;
-  }, [thread, optimisticMessages]);
+  }, [thread, optimisticMessages, showLogs]);
 
   const files = useMemo(() => {
     return thread ? Object.values(thread.filesByName) : [];
   }, [thread]);
 
-  const latestAssistantMessages: z.infer<typeof threadMessageModel>[] = [];
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const message = messages[i]!;
-    const messageType = message.metadata?.message_type ?? '';
-    if (message.role === 'assistant' && !messageType.startsWith('system:')) {
-      latestAssistantMessages.push(message);
-    } else {
-      break;
+  const latestAssistantMessages = useMemo(() => {
+    const result: z.infer<typeof threadMessageModel>[] = [];
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i]!;
+      if (message.role === 'assistant') {
+        result.push(message);
+      } else {
+        break;
+      }
     }
-  }
+    return result;
+  }, [messages]);
 
   const {
     agentRequestsNeedingPermissions,
@@ -391,58 +411,100 @@ export const AgentRunner = ({
               />
 
               {isAuthenticated ? (
-                <Flex align="start" gap="m">
-                  <Text size="text-xs" style={{ marginRight: 'auto' }}>
-                    <b>Shift + Enter</b> to add a new line
-                  </Text>
+                <Flex align="start" gap="m" justify="space-between">
+                  <BreakpointDisplay
+                    show="larger-than-phone"
+                    style={{ marginRight: 'auto' }}
+                  >
+                    <Text size="text-xs">
+                      <b>Shift + Enter</b> to add a new line
+                    </Text>
+                  </BreakpointDisplay>
 
-                  <Flex align="start" gap="xs">
+                  <Flex
+                    align="start"
+                    gap="s"
+                    style={{ paddingRight: '0.15rem' }}
+                  >
                     <BreakpointDisplay show="sidebar-small-screen">
-                      <Button
-                        label="Select Thread"
-                        icon={<List />}
-                        size="small"
-                        fill="ghost"
-                        onClick={() => setThreadsOpenForSmallScreens(true)}
-                      />
+                      <Tooltip asChild content="View all threads">
+                        <Button
+                          label="Select Thread"
+                          icon={<List />}
+                          size="small"
+                          fill="ghost"
+                          onClick={() => setThreadsOpenForSmallScreens(true)}
+                        />
+                      </Tooltip>
                     </BreakpointDisplay>
 
                     <BreakpointDisplay show="sidebar-small-screen">
-                      <Button
-                        label="Edit Parameters"
-                        icon={<Gear />}
-                        size="small"
-                        fill="ghost"
-                        onClick={() => setParametersOpenForSmallScreens(true)}
-                      />
+                      <Tooltip asChild content="View files & settings">
+                        <Button
+                          label={files.length.toString()}
+                          iconLeft={<Folder />}
+                          size="small"
+                          variant="secondary"
+                          fill="ghost"
+                          style={{ paddingInline: '0.5rem' }}
+                          onClick={() => setParametersOpenForSmallScreens(true)}
+                        />
+                      </Tooltip>
                     </BreakpointDisplay>
+
+                    {htmlOutput && (
+                      <Tooltip
+                        asChild
+                        content={
+                          view === 'output'
+                            ? 'View conversation'
+                            : 'View rendered output'
+                        }
+                      >
+                        <Button
+                          label="Toggle View"
+                          icon={
+                            <Eye
+                              weight={view === 'output' ? 'fill' : 'regular'}
+                            />
+                          }
+                          size="small"
+                          variant="secondary"
+                          fill="ghost"
+                          onClick={() =>
+                            view === 'output'
+                              ? setView('conversation', true)
+                              : setView('output', true)
+                          }
+                        />
+                      </Tooltip>
+                    )}
+
+                    <Tooltip
+                      asChild
+                      content={
+                        showLogs ? 'Hide system logs' : 'Show system logs'
+                      }
+                    >
+                      <Button
+                        label={logMessages.length.toString()}
+                        iconLeft={
+                          <Info weight={showLogs ? 'fill' : 'regular'} />
+                        }
+                        size="small"
+                        variant="secondary"
+                        fill="ghost"
+                        style={{ paddingInline: '0.5rem' }}
+                        onClick={() =>
+                          updateQueryPath(
+                            { showLogs: showLogs ? undefined : 'true' },
+                            'replace',
+                            false,
+                          )
+                        }
+                      />
+                    </Tooltip>
                   </Flex>
-
-                  {htmlOutput && (
-                    <>
-                      {view === 'output' ? (
-                        <Tooltip asChild content="Switch to conversation view">
-                          <Button
-                            label="Toggle View"
-                            icon={<Chats />}
-                            size="small"
-                            variant="secondary"
-                            onClick={() => setView('conversation', true)}
-                          />
-                        </Tooltip>
-                      ) : (
-                        <Tooltip asChild content="Switch to output view">
-                          <Button
-                            label="Toggle View"
-                            icon={<Eye />}
-                            size="small"
-                            variant="secondary"
-                            onClick={() => setView('output', true)}
-                          />
-                        </Tooltip>
-                      )}
-                    </>
-                  )}
 
                   <Button
                     label="Send Message"

--- a/hub/demo/src/components/AgentRunner.tsx
+++ b/hub/demo/src/components/AgentRunner.tsx
@@ -15,15 +15,7 @@ import {
   Text,
   Tooltip,
 } from '@near-pagoda/ui';
-import {
-  ArrowRight,
-  Chats,
-  Eye,
-  Folder,
-  Gear,
-  Info,
-  List,
-} from '@phosphor-icons/react';
+import { ArrowRight, Eye, Folder, Info, List } from '@phosphor-icons/react';
 import { useMutation } from '@tanstack/react-query';
 import {
   type KeyboardEventHandler,


### PR DESCRIPTION
Closes: https://github.com/nearai/nearai/issues/568

- The "show logs" button is synced with a `showLogs` URL query param which can also be activated by visiting directly: `/agents/calebjacob.near/html-agent/latest/run?showLogs=true`

<img width="415" alt="Screenshot 2024-11-13 at 10 33 37 AM" src="https://github.com/user-attachments/assets/1b1a60d2-ac67-4f22-9ed8-18923cc8b64c">
