### PR TITLE
Inspect agent source (consumer/chat mode)

### DIFF
--- a/hub/demo/package-lock.json
+++ b/hub/demo/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@gera2ld/tarjs": "^0.3.1",
         "@hookform/resolvers": "^3.6.0",
-        "@near-pagoda/ui": "^2.0.17",
+        "@near-pagoda/ui": "^2.1.1",
         "@near-wallet-selector/bitte-wallet": "8.9.14",
         "@near-wallet-selector/core": "8.9.14",
         "@near-wallet-selector/here-wallet": "8.9.14",
@@ -827,9 +827,9 @@
       }
     },
     "node_modules/@near-pagoda/ui": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@near-pagoda/ui/-/ui-2.0.17.tgz",
-      "integrity": "sha512-f2YLHNLkwNcKXrVUDhzdHbl74hygYP6ax6K2/pjsgpcPMSlgwhNy4klyAgj815ixC4ynwLA8nNWmMLi7F7rPCQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@near-pagoda/ui/-/ui-2.1.1.tgz",
+      "integrity": "sha512-wnTTG5voPuj19xm+nTzq8UKj4p9lObqGG1Ui+3+cuX2xr3u+QJwj6CxgcEIjCkUtGL5lM3NpjbJp8N6ox4+Y1A==",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.5",
         "@radix-ui/colors": "^3.0.0",
@@ -2016,9 +2016,9 @@
       }
     },
     "node_modules/@radix-ui/react-tooltip": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.1.3.tgz",
-      "integrity": "sha512-Z4w1FIS0BqVFI2c1jZvb/uDVJijJjJ2ZMuPV81oVgTZ7g3BZxobplnMVvXtFWgtozdvYJ+MFWtwkM5S2HnAong==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.1.4.tgz",
+      "integrity": "sha512-QpObUH/ZlpaO4YgHSaYzrLO2VuO+ZBFFgGzjMUPwtiYnAzzNNDPJeEGRrT7qNOrWm/Jr08M1vlp+vTHtnSQ0Uw==",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
         "@radix-ui/react-compose-refs": "1.1.0",

--- a/hub/demo/package.json
+++ b/hub/demo/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@gera2ld/tarjs": "^0.3.1",
     "@hookform/resolvers": "^3.6.0",
-    "@near-pagoda/ui": "^2.0.17",
+    "@near-pagoda/ui": "^2.1.1",
     "@near-wallet-selector/bitte-wallet": "8.9.14",
     "@near-wallet-selector/core": "8.9.14",
     "@near-wallet-selector/here-wallet": "8.9.14",

--- a/hub/demo/src/app/competitions/ModelTrainingSeries.tsx
+++ b/hub/demo/src/app/competitions/ModelTrainingSeries.tsx
@@ -249,7 +249,7 @@ const ModelTrainingSeries = () => {
 
                   <Text
                     size="text-xl"
-                    clickableHighlight
+                    indicateParentClickable
                     color={model.status === 'planned' ? 'sand-11' : undefined}
                   >
                     {model.size}

--- a/hub/demo/src/components/AgentRunner.tsx
+++ b/hub/demo/src/components/AgentRunner.tsx
@@ -14,7 +14,14 @@ import {
   Text,
   Tooltip,
 } from '@near-pagoda/ui';
-import { ArrowRight, Eye, Folder, Info, List } from '@phosphor-icons/react';
+import {
+  ArrowRight,
+  CodeBlock,
+  Eye,
+  Folder,
+  Info,
+  List,
+} from '@phosphor-icons/react';
 import { useMutation } from '@tanstack/react-query';
 import {
   type KeyboardEventHandler,
@@ -42,6 +49,7 @@ import {
   useCurrentEntryEnvironmentVariables,
 } from '~/hooks/entries';
 import { useQueryParams } from '~/hooks/url';
+import { sourceUrlForEntry } from '~/lib/entries';
 import { type chatWithAgentModel, type threadMessageModel } from '~/lib/models';
 import { useAuthStore } from '~/stores/auth';
 import { useThreadsStore } from '~/stores/threads';
@@ -423,6 +431,7 @@ export const AgentRunner = ({
                           label="Select Thread"
                           icon={<List />}
                           size="small"
+                          variant="secondary"
                           fill="ghost"
                           onClick={() => setThreadsOpenForSmallScreens(true)}
                         />
@@ -430,7 +439,10 @@ export const AgentRunner = ({
                     </BreakpointDisplay>
 
                     <BreakpointDisplay show="sidebar-small-screen">
-                      <Tooltip asChild content="View files & settings">
+                      <Tooltip
+                        asChild
+                        content="View output files & agent settings"
+                      >
                         <Button
                           label={files.length.toString()}
                           iconLeft={<Folder />}
@@ -495,6 +507,18 @@ export const AgentRunner = ({
                         }
                       />
                     </Tooltip>
+
+                    {env.NEXT_PUBLIC_CONSUMER_MODE && (
+                      <Tooltip asChild content="Inspect agent source">
+                        <Button
+                          label="Agent Source"
+                          icon={<CodeBlock />}
+                          size="small"
+                          fill="ghost"
+                          href={`https://app.near.ai${sourceUrlForEntry(currentEntry)}`}
+                        />
+                      </Tooltip>
+                    )}
                   </Flex>
 
                   <Button
@@ -541,8 +565,7 @@ export const AgentRunner = ({
                           <Flex align="center" gap="s">
                             <Text
                               size="text-s"
-                              color="violet-11"
-                              clickableHighlight
+                              color="sand-12"
                               weight={500}
                               clampLines={1}
                               style={{ marginRight: 'auto' }}

--- a/hub/demo/src/components/EntriesTable.tsx
+++ b/hub/demo/src/components/EntriesTable.tsx
@@ -112,12 +112,7 @@ export const EntriesTable = ({ category, title }: Props) => {
                 style={{ minWidth: '10rem', maxWidth: '20rem' }}
               >
                 <Flex direction="column">
-                  <Text
-                    size="text-s"
-                    weight={500}
-                    color="sand-12"
-                    clickableHighlight
-                  >
+                  <Text size="text-s" weight={600} color="sand-12">
                     {entry.name}
                   </Text>
                   <Text size="text-xs" clampLines={1}>
@@ -130,7 +125,7 @@ export const EntriesTable = ({ category, title }: Props) => {
                 href={`/profiles/${entry.namespace}`}
                 style={{ minWidth: '8rem', maxWidth: '12rem' }}
               >
-                <Text size="text-s" weight={500} clampLines={1}>
+                <Text size="text-s" color="sand-12" clampLines={1}>
                   {entry.namespace}
                 </Text>
               </Table.Cell>

--- a/hub/demo/src/components/EntryCard.tsx
+++ b/hub/demo/src/components/EntryCard.tsx
@@ -34,6 +34,7 @@ export const EntryCard = ({ entry, linksOpenNewTab, footer }: Props) => {
       <Flex gap="s" align="center">
         <ConditionalLink href={primaryUrl}>
           <ImageIcon
+            indicateParentClickable
             src={entry.details.icon}
             alt={entry.name}
             fallbackIcon={icon}

--- a/hub/demo/src/components/EntrySource.tsx
+++ b/hub/demo/src/components/EntrySource.tsx
@@ -121,8 +121,7 @@ export const EntrySource = ({ entry }: Props) => {
                   >
                     <Text
                       size="text-s"
-                      color="violet-11"
-                      clickableHighlight
+                      color="sand-12"
                       weight={500}
                       clampLines={1}
                     >

--- a/hub/demo/src/components/ThreadsSidebar.tsx
+++ b/hub/demo/src/components/ThreadsSidebar.tsx
@@ -131,7 +131,6 @@ export const ThreadsSidebar = ({
                       size="text-s"
                       weight={500}
                       color="sand-12"
-                      clickableHighlight
                       clampLines={1}
                       style={{ marginRight: 'auto' }}
                     >


### PR DESCRIPTION
- Added an "Inspect agent source" icon button in the bottom right when interacting with any agent on `chat.near.ai` - which will redirect you to `app.near.ai/agents/.../source`. CC: @jayzalowitz @ewiner
- Upgraded to `@near-pagoda/ui` 2.1.1 for minor color/focus/hover style improvements for `<Card>` and `<Table>`

<img width="263" alt="Screenshot 2024-11-20 at 11 09 30 AM" src="https://github.com/user-attachments/assets/6885dbc6-ea75-42ff-b938-6fb93eb2312b">
