### PR TITLE
Zustand store DX improvements

### DIFF
--- a/hub/demo/src/components/ZustandHydration.tsx
+++ b/hub/demo/src/components/ZustandHydration.tsx
@@ -7,9 +7,37 @@ import { useEffect } from 'react';
 import { useAgentSettingsStore } from '~/stores/agent-settings';
 import { useAuthStore } from '~/stores/auth';
 
+function migrateLocalStorageStoreNames() {
+  /*
+    This function migrates our legacy Zustand local storage keys 
+    to our new storage key standard before hydrating:
+
+    "store" => "AuthStore"
+    "agent-settings" => "AgentSettingsStore"
+  */
+
+  if (!localStorage.getItem('AuthStore')) {
+    const store = localStorage.getItem('store');
+    if (store) {
+      localStorage.setItem('AuthStore', store);
+      localStorage.removeItem('store');
+    }
+  }
+
+  if (!localStorage.getItem('AgentSettingsStore')) {
+    const store = localStorage.getItem('agent-settings');
+    if (store) {
+      localStorage.setItem('AgentSettingsStore', store);
+      localStorage.removeItem('agent-settings');
+    }
+  }
+}
+
 export const ZustandHydration = () => {
   useEffect(() => {
     const rehydrate = async () => {
+      migrateLocalStorageStoreNames();
+
       await useAuthStore.persist.rehydrate();
       await useAgentSettingsStore.persist.rehydrate();
 

--- a/hub/demo/src/stores/agent-settings.ts
+++ b/hub/demo/src/stores/agent-settings.ts
@@ -46,8 +46,10 @@ const createStore: StateCreator<AgentSettingsStore> = (set, get) => ({
   },
 });
 
+const name = 'AgentSettingsStore';
+
 export const useAgentSettingsStore = create<AgentSettingsStore>()(
-  devtools(
-    persist(createStore, { name: 'agent-settings', skipHydration: true }),
-  ),
+  devtools(persist(createStore, { name, skipHydration: true }), {
+    name,
+  }),
 );

--- a/hub/demo/src/stores/auth.ts
+++ b/hub/demo/src/stores/auth.ts
@@ -16,7 +16,7 @@ type AuthStore = {
   toBearer: () => string;
 };
 
-const createStore: StateCreator<AuthStore> = (set, get) => ({
+const store: StateCreator<AuthStore> = (set, get) => ({
   auth: null,
   currentNonce: null,
   isAuthenticated: false,
@@ -49,6 +49,10 @@ const createStore: StateCreator<AuthStore> = (set, get) => ({
   },
 });
 
+const name = 'AuthStore';
+
 export const useAuthStore = create<AuthStore>()(
-  devtools(persist(createStore, { name: 'store', skipHydration: true })),
+  devtools(persist(store, { name, skipHydration: true }), {
+    name,
+  }),
 );

--- a/hub/demo/src/stores/near.ts
+++ b/hub/demo/src/stores/near.ts
@@ -1,6 +1,7 @@
 import { type Account, type Near } from 'near-api-js';
 import { type BrowserLocalStorageKeyStore } from 'near-api-js/lib/key_stores';
-import { create } from 'zustand';
+import { create, type StateCreator } from 'zustand';
+import { devtools } from 'zustand/middleware';
 
 type NearStore = {
   keyStore: BrowserLocalStorageKeyStore | null;
@@ -12,7 +13,7 @@ type NearStore = {
   setViewAccount: (viewAccount: Account | null) => void;
 };
 
-export const useNearStore = create<NearStore>((set) => ({
+const store: StateCreator<NearStore> = (set) => ({
   keyStore: null,
   near: null,
   viewAccount: null,
@@ -20,4 +21,12 @@ export const useNearStore = create<NearStore>((set) => ({
   setKeyStore: (keyStore) => set({ keyStore }),
   setNear: (near) => set({ near }),
   setViewAccount: (viewAccount) => set({ viewAccount }),
-}));
+});
+
+const name = 'NearStore';
+
+export const useNearStore = create<NearStore>()(
+  devtools(store, {
+    name,
+  }),
+);

--- a/hub/demo/src/stores/threads.ts
+++ b/hub/demo/src/stores/threads.ts
@@ -1,5 +1,6 @@
 import { type z } from 'zod';
-import { create } from 'zustand';
+import { create, type StateCreator } from 'zustand';
+import { devtools } from 'zustand/middleware';
 
 import {
   type chatWithAgentModel,
@@ -36,7 +37,7 @@ type ThreadsStore = {
   ) => void;
 };
 
-export const useThreadsStore = create<ThreadsStore>((set, get) => ({
+const store: StateCreator<ThreadsStore> = (set, get) => ({
   optimisticMessages: [],
   threadsById: {},
 
@@ -127,4 +128,12 @@ export const useThreadsStore = create<ThreadsStore>((set, get) => ({
 
     set({ threadsById, optimisticMessages });
   },
-}));
+});
+
+const name = 'ThreadsStore';
+
+export const useThreadsStore = create<ThreadsStore>()(
+  devtools(store, {
+    name,
+  }),
+);

--- a/hub/demo/src/stores/wallet.ts
+++ b/hub/demo/src/stores/wallet.ts
@@ -6,7 +6,8 @@ import type {
 } from '@near-wallet-selector/core';
 import type { SignMessageMethod } from '@near-wallet-selector/core/src/lib/wallet';
 import type { WalletSelectorModal } from '@near-wallet-selector/modal-ui';
-import { create } from 'zustand';
+import { create, type StateCreator } from 'zustand';
+import { devtools } from 'zustand/middleware';
 
 type WalletStore = {
   account: AccountState | null;
@@ -25,7 +26,7 @@ type WalletStore = {
   setWallet: (wallet: (Wallet & SignMessageMethod) | null) => void;
 };
 
-export const useWalletStore = create<WalletStore>((set) => ({
+const store: StateCreator<WalletStore> = (set) => ({
   account: null,
   hasResolved: false,
   selector: null,
@@ -42,4 +43,12 @@ export const useWalletStore = create<WalletStore>((set) => ({
     return set({ state });
   },
   setWallet: (wallet) => set({ wallet }),
-}));
+});
+
+const name = 'WalletStore';
+
+export const useWalletStore = create<WalletStore>()(
+  devtools(store, {
+    name,
+  }),
+);


### PR DESCRIPTION
This PR updates all of our Zustand stores to use a consistent naming convention and enable the [Redux Devtools](https://github.com/pmndrs/zustand?tab=readme-ov-file#redux-devtools) middleware for all stores. Zustand is completely unrelated to Redux, but Zustand decided to be backwards compatible with existing debug tooling built for Redux.

I thoroughly tested the naming migration and feel comfortable deploying this to production. Any users who are signed in will remain signed in after this deployment (and their local agent settings as well).

Install the Redux Devtools extension: https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd

This will be particularly helpful for our `ThreadsStore` to debug and view the state progression for a thread as messages and file attachments are pulled in over time:

<img width="1918" alt="Screenshot 2024-11-21 at 1 13 20 PM" src="https://github.com/user-attachments/assets/57c9dc40-dc83-4f1a-8b44-0fc25f57a64c">