### PR TITLE
Support "add_secret" iframe post message flow

### DIFF
--- a/hub/demo/package-lock.json
+++ b/hub/demo/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@gera2ld/tarjs": "^0.3.1",
         "@hookform/resolvers": "^3.6.0",
-        "@near-pagoda/ui": "^2.1.1",
+        "@near-pagoda/ui": "^2.1.2",
         "@near-wallet-selector/bitte-wallet": "8.9.14",
         "@near-wallet-selector/core": "8.9.14",
         "@near-wallet-selector/here-wallet": "8.9.14",
@@ -827,9 +827,9 @@
       }
     },
     "node_modules/@near-pagoda/ui": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@near-pagoda/ui/-/ui-2.1.1.tgz",
-      "integrity": "sha512-wnTTG5voPuj19xm+nTzq8UKj4p9lObqGG1Ui+3+cuX2xr3u+QJwj6CxgcEIjCkUtGL5lM3NpjbJp8N6ox4+Y1A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@near-pagoda/ui/-/ui-2.1.2.tgz",
+      "integrity": "sha512-se0YWwhyvhDD0pILhJNIxUhdP7NA74Ox5lU/ET6U5Mbk/1G0ktaLNXz1kBW9pv0jrMjLQnXwSvdk5dHZhXVc/g==",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.5",
         "@radix-ui/colors": "^3.0.0",

--- a/hub/demo/package.json
+++ b/hub/demo/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@gera2ld/tarjs": "^0.3.1",
     "@hookform/resolvers": "^3.6.0",
-    "@near-pagoda/ui": "^2.1.1",
+    "@near-pagoda/ui": "^2.1.2",
     "@near-wallet-selector/bitte-wallet": "8.9.14",
     "@near-wallet-selector/core": "8.9.14",
     "@near-wallet-selector/here-wallet": "8.9.14",

--- a/hub/demo/src/components/AgentPermissionsModal.tsx
+++ b/hub/demo/src/components/AgentPermissionsModal.tsx
@@ -1,12 +1,30 @@
-import { Button, Dialog, Flex, SvgIcon, Text } from '@near-pagoda/ui';
-import { Check, Prohibit } from '@phosphor-icons/react';
-import { useEffect } from 'react';
+import {
+  Button,
+  Card,
+  CardList,
+  copyTextToClipboard,
+  Dialog,
+  Flex,
+  SvgIcon,
+  Text,
+  Tooltip,
+} from '@near-pagoda/ui';
+import {
+  Check,
+  Copy,
+  Eye,
+  EyeSlash,
+  LockKey,
+  Prohibit,
+} from '@phosphor-icons/react';
+import { useEffect, useState } from 'react';
 import { type z } from 'zod';
 
 import { useEntryParams } from '~/hooks/entries';
 import { idMatchesEntry } from '~/lib/entries';
 import {
-  type agentWalletTransactionsRequestModel,
+  type agentAddSecretsRequestModel,
+  type agentNearSendTransactionsRequestModel,
   type chatWithAgentModel,
   type entryModel,
 } from '~/lib/models';
@@ -15,42 +33,59 @@ import { useAuthStore } from '~/stores/auth';
 
 import { SignInPrompt } from './SignInPrompt';
 
-export type AgentRequest =
-  | z.infer<typeof chatWithAgentModel>
-  | z.infer<typeof agentWalletTransactionsRequestModel>;
+export type AgentRequestWithPermissions =
+  | {
+      action: 'add_secrets';
+      input: z.infer<typeof agentAddSecretsRequestModel>;
+    }
+  | {
+      action: 'remote_agent_run';
+      input: z.infer<typeof chatWithAgentModel>;
+    }
+  | {
+      action: 'near_send_transactions';
+      input: z.infer<typeof agentNearSendTransactionsRequestModel>;
+    };
 
 type Props = {
   agent: z.infer<typeof entryModel>;
-  requests: AgentRequest[] | null;
+  requests: AgentRequestWithPermissions[] | null;
   clearRequests: () => unknown;
-  onAllow: (requests: AgentRequest[]) => unknown;
+  onAllow: (requests: AgentRequestWithPermissions[]) => unknown;
 };
 
 export function checkAgentPermissions(
   agent: z.infer<typeof entryModel>,
-  requests: AgentRequest[],
+  requests: AgentRequestWithPermissions[],
 ) {
   const settings = useAgentSettingsStore.getState().getAgentSettings(agent);
+  let allowAddSecrets = true;
   let allowRemoteRunCallsToOtherAgents = true;
   let allowWalletTransactionRequests = true;
 
-  requests.forEach((request) => {
-    if ('agent_id' in request) {
+  requests.forEach(({ action, input }) => {
+    if (action === 'add_secrets') {
+      // Always prompt a user for permission to add secrets
+      allowAddSecrets = false;
+    } else if (action === 'remote_agent_run') {
       allowRemoteRunCallsToOtherAgents =
-        idMatchesEntry(request.agent_id, agent) ||
+        idMatchesEntry(input.agent_id, agent) ||
         !!settings.allowRemoteRunCallsToOtherAgents;
-    } else {
+    } else if (action === 'near_send_transactions') {
       allowWalletTransactionRequests =
         !!settings.allowWalletTransactionRequests;
     }
   });
 
   const allowed =
-    allowRemoteRunCallsToOtherAgents && allowWalletTransactionRequests;
+    allowAddSecrets &&
+    allowRemoteRunCallsToOtherAgents &&
+    allowWalletTransactionRequests;
 
   return {
     allowed,
     permissions: {
+      allowAddSecrets,
       allowRemoteRunCallsToOtherAgents,
       allowWalletTransactionRequests,
     },
@@ -71,8 +106,8 @@ export const AgentPermissionsModal = ({
   );
   const check = requests ? checkAgentPermissions(agent, requests) : undefined;
   const otherAgentId = requests?.find(
-    (request) => 'agent_id' in request,
-  )?.agent_id;
+    (request) => request.action === 'remote_agent_run',
+  )?.input.agent_id;
 
   const decline = () => {
     clearRequests();
@@ -117,128 +152,275 @@ export const AgentPermissionsModal = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const requestsThatCanBeAlwaysAllowed =
+    requests?.filter(({ action }) => action !== 'add_secrets') ?? [];
+
+  const secretsToAdd = (requests ?? [])
+    .flatMap((request) =>
+      request.action === 'add_secrets' ? request.input.secrets : null,
+    )
+    .filter((value) => !!value);
+
   return (
     <Dialog.Root open={requests !== null} onOpenChange={() => clearRequests()}>
-      <Dialog.Content title="Agent Run Request" size="s">
-        {isAuthenticated ? (
+      <Dialog.Content title="Agent Request" size="s">
+        {check && (
           <>
-            <Flex direction="column" gap="l">
-              {!check?.permissions.allowRemoteRunCallsToOtherAgents && (
-                <>
-                  <Text>
-                    The current agent{' '}
-                    <Text href={`/agents/${agentId}`} target="_blank">
-                      {agentId}
-                    </Text>{' '}
-                    wants to send an additional request to a different agent{' '}
-                    <Text href={`/agents/${otherAgentId}`} target="_blank">
-                      {otherAgentId}
-                    </Text>{' '}
-                    using your {`account's`} signature{' '}
-                    <Text as="span" color="sand-12" weight={500}>
-                      {auth?.account_id}
+            {isAuthenticated ? (
+              <Flex direction="column" gap="l">
+                {!check.permissions.allowAddSecrets && (
+                  <>
+                    <Text>
+                      The current agent{' '}
+                      <Text href={`/agents/${agentId}`} target="_blank">
+                        {agentId}
+                      </Text>{' '}
+                      wants to save {secretsToAdd.length}
+                      {` secret${secretsToAdd.length === 1 ? '' : 's'}`} to your
+                      account. Secrets are only visible to you and the specified
+                      agent.
                     </Text>
-                  </Text>
 
-                  <Flex direction="column" gap="m">
-                    <Flex align="baseline" gap="s">
-                      <SvgIcon
-                        size="xs"
-                        icon={<Check weight="bold" />}
-                        color="green-10"
-                      />
-                      <Text size="text-s">
-                        Allow the agent to execute actions within the Near AI
-                        Hub.
+                    <SecretsToAdd secrets={secretsToAdd} />
+                  </>
+                )}
+
+                {!check.permissions.allowRemoteRunCallsToOtherAgents && (
+                  <>
+                    <Text>
+                      The current agent{' '}
+                      <Text href={`/agents/${agentId}`} target="_blank">
+                        {agentId}
+                      </Text>{' '}
+                      wants to send an additional request to a different agent{' '}
+                      <Text href={`/agents/${otherAgentId}`} target="_blank">
+                        {otherAgentId}
+                      </Text>{' '}
+                      using your {`account's`} signature{' '}
+                      <Text as="span" color="sand-12" weight={500}>
+                        {auth?.account_id}
                       </Text>
-                    </Flex>
+                    </Text>
 
-                    <Flex align="baseline" gap="s">
-                      <SvgIcon
-                        size="xs"
-                        icon={<Prohibit weight="bold" />}
-                        color="red-10"
+                    <Flex direction="column" gap="m">
+                      <Flex align="baseline" gap="s">
+                        <SvgIcon
+                          size="xs"
+                          icon={<Check weight="bold" />}
+                          color="green-10"
+                        />
+                        <Text size="text-s">
+                          Allow the agent to execute actions within the Near AI
+                          Hub.
+                        </Text>
+                      </Flex>
+
+                      <Flex align="baseline" gap="s">
+                        <SvgIcon
+                          size="xs"
+                          icon={<Prohibit weight="bold" />}
+                          color="red-10"
+                        />
+                        <Text size="text-s">
+                          Will NOT allow the agent to perform actions on your
+                          NEAR blockchain account.
+                        </Text>
+                      </Flex>
+                    </Flex>
+                  </>
+                )}
+
+                {!check.permissions.allowWalletTransactionRequests && (
+                  <>
+                    <Text>
+                      The current agent{' '}
+                      <Text href={`/agents/${agentId}`} target="_blank">
+                        {agentId}
+                      </Text>{' '}
+                      wants to request a wallet transaction. If allowed, you
+                      will be prompted to review the transaction within your
+                      connected wallet.
+                    </Text>
+
+                    <Flex direction="column" gap="m">
+                      <Flex align="baseline" gap="s">
+                        <SvgIcon
+                          size="xs"
+                          icon={<Check weight="bold" />}
+                          color="green-10"
+                        />
+                        <Text size="text-s">
+                          Allow the agent to request wallet transactions. You
+                          will review each request within your connected wallet
+                          before deciding to approve or deny it.
+                        </Text>
+                      </Flex>
+
+                      <Flex align="baseline" gap="s">
+                        <SvgIcon
+                          size="xs"
+                          icon={<Prohibit weight="bold" />}
+                          color="red-10"
+                        />
+                        <Text size="text-s">
+                          Will NOT allow the agent to perform wallet
+                          transactions on your behalf without your consent.
+                        </Text>
+                      </Flex>
+                    </Flex>
+                  </>
+                )}
+
+                <Flex gap="s">
+                  <Button
+                    label="Decline"
+                    variant="secondary"
+                    style={{ marginRight: 'auto' }}
+                    size="small"
+                    onClick={decline}
+                  />
+
+                  {requestsThatCanBeAlwaysAllowed.length > 0 ? (
+                    <>
+                      <Button
+                        label="Allow Once"
+                        variant="affirmative"
+                        fill="outline"
+                        size="small"
+                        onClick={allow}
                       />
-                      <Text size="text-s">
-                        Will NOT allow the agent to perform actions on your NEAR
-                        blockchain account.
-                      </Text>
-                    </Flex>
-                  </Flex>
-                </>
-              )}
-
-              {!check?.permissions.allowWalletTransactionRequests && (
-                <>
-                  <Text>
-                    The current agent{' '}
-                    <Text href={`/agents/${agentId}`} target="_blank">
-                      {agentId}
-                    </Text>{' '}
-                    wants to request a wallet transaction. If allowed, you will
-                    be prompted to review the transaction within your connected
-                    wallet.
-                  </Text>
-
-                  <Flex direction="column" gap="m">
-                    <Flex align="baseline" gap="s">
-                      <SvgIcon
-                        size="xs"
-                        icon={<Check weight="bold" />}
-                        color="green-10"
+                      <Button
+                        label="Always Allow"
+                        variant="affirmative"
+                        size="small"
+                        onClick={alwaysAllow}
                       />
-                      <Text size="text-s">
-                        Allow the agent to request wallet transactions. You will
-                        review each request within your connected wallet before
-                        deciding to approve or deny it.
-                      </Text>
-                    </Flex>
-
-                    <Flex align="baseline" gap="s">
-                      <SvgIcon
-                        size="xs"
-                        icon={<Prohibit weight="bold" />}
-                        color="red-10"
-                      />
-                      <Text size="text-s">
-                        Will NOT allow the agent to perform wallet transactions
-                        on your behalf without your consent.
-                      </Text>
-                    </Flex>
-                  </Flex>
-                </>
-              )}
-
-              <Flex gap="s">
-                <Button
-                  label="Decline"
-                  variant="secondary"
-                  style={{ marginRight: 'auto' }}
-                  size="small"
-                  onClick={decline}
-                />
-                <Button
-                  label="Allow Once"
-                  variant="affirmative"
-                  fill="outline"
-                  size="small"
-                  onClick={allow}
-                />
-                <Button
-                  label="Always Allow"
-                  variant="affirmative"
-                  size="small"
-                  onClick={alwaysAllow}
-                />
+                    </>
+                  ) : (
+                    <Button
+                      label="Allow"
+                      variant="affirmative"
+                      size="small"
+                      onClick={allow}
+                    />
+                  )}
+                </Flex>
               </Flex>
-            </Flex>
-          </>
-        ) : (
-          <>
-            <SignInPrompt />
+            ) : (
+              <SignInPrompt />
+            )}
           </>
         )}
       </Dialog.Content>
     </Dialog.Root>
+  );
+};
+
+const SecretsToAdd = ({
+  secrets,
+}: {
+  secrets: {
+    key: string;
+    value: string;
+    agentId: string;
+  }[];
+}) => {
+  const [revealedSecretKeys, setRevealedSecretKeys] = useState<string[]>([]);
+
+  const toggleRevealSecret = (key: string) => {
+    const revealed = revealedSecretKeys.find((k) => k === key);
+    setRevealedSecretKeys((keys) => {
+      if (!revealed) {
+        return [...keys, key];
+      }
+      return keys.filter((k) => k !== key);
+    });
+  };
+
+  if (secrets.length === 0) return null;
+
+  return (
+    <CardList>
+      {secrets.map((secret) => (
+        <Card gap="xs" padding="s" key={secret.key} background="sand-2">
+          <Flex align="center" gap="m">
+            <Text size="text-s" weight={500} color="sand-12" forceWordBreak>
+              {secret.key}
+            </Text>
+
+            <Flex
+              gap="xs"
+              style={{
+                position: 'relative',
+                top: '0.15rem',
+                marginLeft: 'auto',
+              }}
+            >
+              <Tooltip
+                asChild
+                content={`${revealedSecretKeys.includes(secret.key) ? 'Hide' : 'Show'} Secret`}
+              >
+                <Button
+                  label="Show/Hide Secret"
+                  icon={
+                    revealedSecretKeys.includes(secret.key) ? (
+                      <EyeSlash />
+                    ) : (
+                      <Eye />
+                    )
+                  }
+                  size="x-small"
+                  fill="ghost"
+                  variant="primary"
+                  onClick={() => {
+                    toggleRevealSecret(secret.key);
+                  }}
+                />
+              </Tooltip>
+
+              <Tooltip asChild content="Copy to clipboard">
+                <Button
+                  label="Copy to clipboard"
+                  icon={<Copy />}
+                  size="x-small"
+                  fill="ghost"
+                  variant="primary"
+                  onClick={() => copyTextToClipboard(secret.value)}
+                />
+              </Tooltip>
+            </Flex>
+          </Flex>
+
+          <Flex align="baseline" gap="s">
+            <SvgIcon
+              style={{
+                position: 'relative',
+                top: '0.15rem',
+              }}
+              icon={<LockKey />}
+              color="sand-10"
+              size="xs"
+            />
+
+            <Text size="text-xs" family="monospace" forceWordBreak>
+              {revealedSecretKeys.includes(secret.key) ? secret.value : '*****'}
+            </Text>
+          </Flex>
+
+          <Tooltip content="This secret will be scoped to this agent" asChild>
+            <Text
+              size="text-2xs"
+              color="sand-10"
+              href={`/agents/${secret.agentId}`}
+              target="_blank"
+              decoration="none"
+              style={{ marginLeft: 'auto' }}
+            >
+              {secret.agentId}
+            </Text>
+          </Tooltip>
+        </Card>
+      ))}
+    </CardList>
   );
 };

--- a/hub/demo/src/components/AgentRunner.tsx
+++ b/hub/demo/src/components/AgentRunner.tsx
@@ -217,6 +217,7 @@ export const AgentRunner = ({
     agentRequestsNeedingPermissions,
     setAgentRequestsNeedingPermissions,
     conditionallyProcessAgentRequests,
+    iframeNonce,
     iframePostMessage,
     onIframePostMessage,
   } = useAgentRequestsWithIframe(currentEntry, chatMutation, threadId);
@@ -375,6 +376,7 @@ export const AgentRunner = ({
                 <>
                   <IframeWithBlob
                     html={htmlOutput}
+                    nonce={iframeNonce}
                     onPostMessage={onIframePostMessage}
                     postMessage={iframePostMessage}
                   />

--- a/hub/demo/src/components/EntryEnvironmentVariables.tsx
+++ b/hub/demo/src/components/EntryEnvironmentVariables.tsx
@@ -333,16 +333,6 @@ const SecretForm = ({ entry, existingVariable, onFinish }: SecretFormProps) => {
 
   const onSubmit: SubmitHandler<SecretFormSchema> = async (data) => {
     try {
-      if (existingVariable?.secret) {
-        await removeMutation.mutateAsync({
-          category: entry.category,
-          key: existingVariable.key,
-          name: entry.name,
-          namespace: entry.namespace,
-          version: entry.version,
-        });
-      }
-
       await addMutation.mutateAsync({
         category: entry.category,
         key: data.key,

--- a/hub/demo/src/components/lib/IframeWithBlob.tsx
+++ b/hub/demo/src/components/lib/IframeWithBlob.tsx
@@ -12,8 +12,9 @@ export type IframePostMessageEventHandler<T = any> = (
   },
 ) => unknown;
 
-type Props = ComponentProps<'iframe'> & {
+type Props = Omit<ComponentProps<'iframe'>, 'nonce'> & {
   html: string;
+  nonce?: number | null;
   onPostMessage?: IframePostMessageEventHandler;
   postMessage?: unknown;
 };
@@ -21,6 +22,7 @@ type Props = ComponentProps<'iframe'> & {
 export const IframeWithBlob = ({
   className = '',
   html,
+  nonce,
   onPostMessage,
   postMessage,
   ...props
@@ -88,10 +90,12 @@ export const IframeWithBlob = ({
 
     setDataUrl(url);
 
+    console.log(url);
+
     return () => {
       URL.revokeObjectURL(url);
     };
-  }, [html]);
+  }, [html, nonce]);
 
   useEffect(() => {
     function messageListener(event: MessageEvent) {

--- a/hub/demo/src/hooks/agent-iframe-requests.ts
+++ b/hub/demo/src/hooks/agent-iframe-requests.ts
@@ -1,3 +1,4 @@
+import { handleClientError } from '@near-pagoda/ui';
 import { type FinalExecutionOutcome } from '@near-wallet-selector/core';
 import { type UseMutationResult } from '@tanstack/react-query';
 import { formatNearAmount } from 'near-api-js/lib/utils/format';
@@ -5,15 +6,17 @@ import { useCallback, useEffect, useState } from 'react';
 import { type z } from 'zod';
 
 import {
-  type AgentRequest,
+  type AgentRequestWithPermissions,
   checkAgentPermissions,
 } from '~/components/AgentPermissionsModal';
 import { type AgentChatMutationInput } from '~/components/AgentRunner';
 import { type IframePostMessageEventHandler } from '~/components/lib/IframeWithBlob';
+import { parseEntryId } from '~/lib/entries';
 import {
-  agentWalletAccountRequestModel,
-  agentWalletTransactionsRequestModel,
-  agentWalletViewRequestModel,
+  agentAddSecretsRequestModel,
+  agentNearAccountRequestModel,
+  agentNearSendTransactionsRequestModel,
+  agentNearViewRequestModel,
   chatWithAgentModel,
   type entryModel,
 } from '~/lib/models';
@@ -26,6 +29,14 @@ import { useQueryParams } from './url';
 
 const PENDING_TRANSACTION_KEY = 'agent-transaction-request-pending-connection';
 
+export type AgentActionType =
+  | 'add_secrets'
+  | 'near_account'
+  | 'near_send_transactions'
+  | 'near_view'
+  | 'remote_agent_run'
+  | 'refresh_thread_id';
+
 export function useAgentRequestsWithIframe(
   currentEntry: z.infer<typeof entryModel> | undefined,
   chatMutation: UseMutationResult<
@@ -36,6 +47,7 @@ export function useAgentRequestsWithIframe(
   >,
   threadId: string | null | undefined,
 ) {
+  const addSecretMutation = api.hub.addSecret.useMutation();
   const { queryParams, updateQueryPath } = useQueryParams([
     'account_id',
     'threadId',
@@ -49,8 +61,9 @@ export function useAgentRequestsWithIframe(
   const nearViewAccount = useNearStore((store) => store.viewAccount);
   const near = useNearStore((store) => store.near);
   const [iframePostMessage, setIframePostMessage] = useState<unknown>(null);
+  const [iframeNonce, setIframeNonce] = useState<number | null>(null);
   const [agentRequestsNeedingPermissions, setAgentRequestsNeedingPermissions] =
-    useState<AgentRequest[] | null>(null);
+    useState<AgentRequestWithPermissions[] | null>(null);
   const utils = api.useUtils();
 
   const handleWalletTransactionResponse = useCallback(
@@ -86,7 +99,7 @@ export function useAgentRequestsWithIframe(
   );
 
   const conditionallyProcessAgentRequests = async (
-    requests: AgentRequest[],
+    requests: AgentRequestWithPermissions[],
     allowedBypass?: boolean,
   ) => {
     if (!currentEntry) return;
@@ -94,29 +107,68 @@ export function useAgentRequestsWithIframe(
     const permissionsCheck = checkAgentPermissions(currentEntry, requests);
 
     if (allowedBypass ?? permissionsCheck.allowed) {
-      requests.forEach(async (request) => {
-        if ('agent_id' in request) {
-          await chatMutation.mutateAsync(request);
-        } else {
+      requests.forEach(async ({ action, input }) => {
+        if (action === 'add_secrets') {
+          const addedKeys: string[] = [];
+          const failedKeys: string[] = [];
+
+          for (const secret of input.secrets) {
+            try {
+              const { name, namespace, version } = parseEntryId(secret.agentId);
+              await addSecretMutation.mutateAsync({
+                category: 'agent',
+                key: secret.key,
+                name,
+                namespace,
+                value: secret.value,
+                version,
+              });
+              addedKeys.push(secret.key);
+            } catch (error) {
+              handleClientError({
+                error,
+                title: `Failed to save secret: ${secret.key}`,
+              });
+              failedKeys.push(secret.key);
+            }
+          }
+
+          setIframePostMessage({
+            action: 'add_secrets_response',
+            requestId: input.requestId,
+            result: {
+              addedKeys,
+              failedKeys,
+            },
+          });
+
+          await utils.hub.secrets.refetch();
+
+          if (input.reloadAgentOnSuccess) {
+            setIframeNonce(Date.now()); // This will trigger the iframe to reload
+          }
+        } else if (action === 'remote_agent_run') {
+          await chatMutation.mutateAsync(input);
+        } else if (action === 'near_send_transactions') {
           if (wallet) {
             try {
               const callbackUrl = new URL(window.location.href);
-              if (request.requestId) {
+              if (input.requestId) {
                 callbackUrl.searchParams.set(
                   'transactionRequestId',
-                  request.requestId,
+                  input.requestId,
                 );
               }
 
               const result = await wallet.signAndSendTransactions({
-                transactions: request.transactions,
+                transactions: input.transactions,
                 callbackUrl: callbackUrl.toString(),
               });
 
               if (result) {
                 handleWalletTransactionResponse({
                   result,
-                  requestId: request.requestId,
+                  requestId: input.requestId,
                 });
               }
             } catch (error) {
@@ -125,10 +177,12 @@ export function useAgentRequestsWithIframe(
           } else {
             localStorage.setItem(
               PENDING_TRANSACTION_KEY,
-              JSON.stringify(request),
+              JSON.stringify(input),
             );
             walletSignInModal!.show();
           }
+        } else {
+          unreachable(action);
         }
       });
     } else {
@@ -137,37 +191,35 @@ export function useAgentRequestsWithIframe(
   };
 
   const onIframePostMessage: IframePostMessageEventHandler<{
-    action:
-      | 'near_account'
-      | 'near_send_transactions'
-      | 'near_view'
-      | 'remote_agent_run'
-      | 'refresh_thread_id';
+    action: AgentActionType;
     data: unknown;
   }> = async (event) => {
     try {
       const action = event.data.action;
 
       if (action === 'near_send_transactions') {
-        const request = agentWalletTransactionsRequestModel.parse(
+        const input = agentNearSendTransactionsRequestModel.parse(
           event.data.data,
         );
-        void conditionallyProcessAgentRequests([request]);
+        void conditionallyProcessAgentRequests([
+          {
+            action,
+            input,
+          },
+        ]);
       } else if (action === 'near_view') {
-        const request = agentWalletViewRequestModel.parse(event.data.data);
-        const result: unknown = await nearViewAccount!.viewFunction(request);
+        const input = agentNearViewRequestModel.parse(event.data.data);
+        const result: unknown = await nearViewAccount!.viewFunction(input);
         setIframePostMessage({
           action: 'near_view_response',
-          requestId: request.requestId,
+          requestId: input.requestId,
           result,
         });
       } else if (action === 'near_account') {
-        const request = agentWalletAccountRequestModel.parse(event.data.data);
-
-        let accountId = request.accountId;
+        const input = agentNearAccountRequestModel.parse(event.data.data);
+        let accountId = input.accountId;
 
         if (!accountId && selector) {
-          // get current accountId
           const isSignedIn = selector.isSignedIn();
           if (isSignedIn) {
             const accounts = selector.store.getState().accounts;
@@ -184,23 +236,36 @@ export function useAgentRequestsWithIframe(
           const NEAR = formatNearAmount(yNEAR, 2).replace(/,/g, '');
           setIframePostMessage({
             action: 'near_account_response',
-            requestId: request.requestId,
+            requestId: input.requestId,
             result: { accountId, balance: NEAR, yNEAR },
           });
         } else {
           console.error('Missing data read `near_account`');
         }
       } else if (action === 'refresh_thread_id') {
-        const chat = chatWithAgentModel.partial().parse(event.data.data);
-        if (chat.thread_id) {
+        const input = chatWithAgentModel.partial().parse(event.data.data);
+        if (input.thread_id) {
           void utils.hub.thread.invalidate();
-          updateQueryPath({ threadId: chat.thread_id }, 'replace', false);
+          updateQueryPath({ threadId: input.thread_id }, 'replace', false);
         }
       } else if (action === 'remote_agent_run') {
-        const chat = chatWithAgentModel.parse(event.data.data);
-        chat.max_iterations = Number(chat.max_iterations) || 1;
-        chat.thread_id = chat.thread_id ?? threadId;
-        void conditionallyProcessAgentRequests([chat]);
+        const input = chatWithAgentModel.parse(event.data.data);
+        input.max_iterations = Number(input.max_iterations) || 1;
+        input.thread_id = input.thread_id ?? threadId;
+        void conditionallyProcessAgentRequests([
+          {
+            action,
+            input,
+          },
+        ]);
+      } else if (action === 'add_secrets') {
+        const input = agentAddSecretsRequestModel.parse(event.data.data);
+        void conditionallyProcessAgentRequests([
+          {
+            action,
+            input,
+          },
+        ]);
       } else {
         unreachable(action);
       }
@@ -212,9 +277,14 @@ export function useAgentRequestsWithIframe(
   useEffect(() => {
     if (currentEntry && wallet) {
       try {
-        const rawRequest = localStorage.getItem(PENDING_TRANSACTION_KEY);
-        if (rawRequest) {
-          const request = JSON.parse(rawRequest) as AgentRequest;
+        const rawInput = localStorage.getItem(PENDING_TRANSACTION_KEY);
+        if (rawInput) {
+          const request: AgentRequestWithPermissions = {
+            action: 'near_send_transactions',
+            input: JSON.parse(rawInput) as z.infer<
+              typeof agentNearSendTransactionsRequestModel
+            >,
+          };
           void conditionallyProcessAgentRequests([request], true);
         }
       } catch (error) {
@@ -239,6 +309,7 @@ export function useAgentRequestsWithIframe(
   return {
     agentRequestsNeedingPermissions,
     conditionallyProcessAgentRequests,
+    iframeNonce,
     iframePostMessage,
     onIframePostMessage,
     setAgentRequestsNeedingPermissions,

--- a/hub/demo/src/lib/models.ts
+++ b/hub/demo/src/lib/models.ts
@@ -222,7 +222,7 @@ const walletTransactionActionModel = z.discriminatedUnion('type', [
   }),
 ]);
 
-export const agentWalletTransactionsRequestModel = z.object({
+export const agentNearSendTransactionsRequestModel = z.object({
   transactions: z
     .object({
       signerId: z.string().optional(),
@@ -233,7 +233,7 @@ export const agentWalletTransactionsRequestModel = z.object({
   requestId: z.string().nullish(),
 });
 
-export const agentWalletViewRequestModel = z.object({
+export const agentNearViewRequestModel = z.object({
   contractId: z.string(),
   methodName: z.string(),
   args: z.record(z.string(), z.unknown()).optional(),
@@ -255,9 +255,17 @@ export const agentWalletViewRequestModel = z.object({
     .optional(),
 });
 
-export const agentWalletAccountRequestModel = z.object({
+export const agentNearAccountRequestModel = z.object({
   accountId: z.string().nullable().default(''),
   requestId: z.string().nullish(),
+});
+
+export const agentAddSecretsRequestModel = z.object({
+  secrets: z
+    .object({ agentId: z.string(), key: z.string(), value: z.string() })
+    .array(),
+  requestId: z.string().nullish(),
+  reloadAgentOnSuccess: z.boolean().default(true),
 });
 
 export const threadMetadataModel = z.intersection(

--- a/hub/demo/src/server/utils/secrets.ts
+++ b/hub/demo/src/server/utils/secrets.ts
@@ -1,0 +1,46 @@
+import { env } from 'process';
+
+import { entrySecretModel } from '~/lib/models';
+import { type RouterInputs } from '~/trpc/react';
+import { createZodFetcher } from '~/utils/zod-fetch';
+
+const fetchWithZod = createZodFetcher();
+
+export async function conditionallyRemoveSecret(
+  authorization: string,
+  input: RouterInputs['hub']['addSecret'],
+) {
+  const secretsUrl = new URL(`${env.ROUTER_URL}/get_user_secrets`);
+  secretsUrl.searchParams.append('limit', '10000');
+
+  const secrets = await fetchWithZod(
+    entrySecretModel.array(),
+    secretsUrl.toString(),
+    {
+      headers: {
+        Authorization: authorization,
+      },
+    },
+  );
+
+  const existingSecret = secrets.find(
+    (secret) =>
+      secret.key === input.key &&
+      secret.namespace === input.namespace &&
+      secret.name === input.name &&
+      secret.version === input.version,
+  );
+
+  if (existingSecret) {
+    const removeUrl = `${env.ROUTER_URL}/remove_hub_secret`;
+
+    await fetch(removeUrl, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: authorization,
+      },
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  }
+}


### PR DESCRIPTION
Closes: https://github.com/nearai/nearai/issues/592

- If the user allows the secrets to be added, any conflicting secret key will be removed before the new value is added (any previous value will be overwritten). We can probably polish the UX further overt time here.
- The `Always Allow` option isn't applicable for `add_secrets` since we always want to notify the user when an agent is adding a secret. The UI simply shows an `Allow` button if the agent is only adding requesting to add secrets.
-  Went with `add_secrets` and `add_secrets_response` action names to handle the case where an agent wants to add multiple at once.
- The iframe is reloaded if `reloadAgentOnSuccess` is true (which defaults to `true`) after the secrets were added

Request via `add_secret` action:

```ts
const agentAddSecretsRequestModel = z.object({
  secrets: z
    .object({ agentId: z.string(), key: z.string(), value: z.string() })
    .array(),
  requestId: z.string().nullish(),
  reloadAgentOnSuccess: z.boolean().default(true),
});
```

Response via `add_secret_response` action:

```
{
  action: 'add_secrets_response';
  requestId?: string;
  result: {
    addedKeys: string[];
    failedKeys: string[];
  };
}
```