### PR TITLE
Handle 'qwen-q' prefix in name matching

### DIFF
--- a/nearai/shared/naming.py
+++ b/nearai/shared/naming.py
@@ -32,6 +32,8 @@ def get_canonical_name(name: str) -> str:
     name = re.sub(r"(?<!\d)_|_(?!\d)", "", name)
     # Convert 'metallama' to 'llama'
     name = name.replace("metallama", "llama")
+    # Convert 'qwenq' to 'q'
+    name = name.replace("qwenq", "q")
     return name
 
 
@@ -52,6 +54,9 @@ def create_registry_name(name: str) -> str:
     # Convert 'metallama' or 'meta-llama' to 'llama'
     name = name.replace("metallama", "llama")
     name = name.replace("meta-llama", "llama")
+    # Convert 'qwenq' or 'qwen-q' to 'q'
+    name = name.replace("qwenq", "q")
+    name = name.replace("qwen-q", "q")
     return name
 
 

--- a/nearai/shared/tests/test_naming.py
+++ b/nearai/shared/tests/test_naming.py
@@ -44,6 +44,9 @@ class TestGetCanonicalName(unittest.TestCase):
     def test_metallama_conversion(self):  # noqa: D102
         self.assertEqual(get_canonical_name("metallama-3b"), "llama3b")
 
+    def test_qwenq_conversion(self):  # noqa: D102
+        self.assertEqual(get_canonical_name("qwen-qwq"), "qwq")
+
     def test_v_digit_conversion(self):  # noqa: D102
         self.assertEqual(get_canonical_name("llama-v2-7b"), "llama2_7b")
         self.assertEqual(get_canonical_name("gpt-v4"), "gpt4")


### PR DESCRIPTION
Before:
```
[0] nearai registry upload-unregistered-common-provider-models
Going to create new registry items:
┌────────────────────────────────────────────────┬────────────────────────────────────────────────────┐
│ entry                                          │ description                                        │
├────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ near.ai/qwen2p5-coder-32b-instruct/1.0.0       │ hyperbolic::Qwen/Qwen2.5-Coder-32B-Instruct & fire │
│                                                │ works::accounts/fireworks/models/qwen2p5-coder-    │
│                                                │ 32b-instruct                                       │
├────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ near.ai/qwq-32b-preview/1.0.0                  │ hyperbolic::Qwen/QwQ-32B-Preview                   │
├────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ near.ai/flux-1-schnell-fp8/1.0.0               │ fireworks::accounts/fireworks/models/flux-1-       │
│                                                │ schnell-fp8                                        │
├────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ near.ai/flux-1-dev-fp8/1.0.0                   │ fireworks::accounts/fireworks/models/flux-1-dev-   │
│                                                │ fp8                                                │
├────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ near.ai/stable-diffusion-3p5-medium/1.0.0      │ fireworks::accounts/fireworks/models/stable-       │
│                                                │ diffusion-3p5-medium                               │
├────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ near.ai/stable-diffusion-3p5-large/1.0.0       │ fireworks::accounts/fireworks/models/stable-       │
│                                                │ diffusion-3p5-large                                │
├────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ near.ai/stable-diffusion-3p5-large-turbo/1.0.0 │ fireworks::accounts/fireworks/models/stable-       │
│                                                │ diffusion-3p5-large-turbo                          │
├────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ near.ai/qwen-qwq-32b-preview/1.0.0             │ fireworks::accounts/fireworks/models/qwen-         │
│                                                │ qwq-32b-preview                                    │
└────────────────────────────────────────────────┴────────────────────────────────────────────────────┘
Please verify, then repeat the command with --dry_run=False
```

After:
```
[0] nearai registry upload-unregistered-common-provider-models
Going to create new registry items:
┌────────────────────────────────────────────────┬────────────────────────────────────────────────────┐
│ entry                                          │ description                                        │
├────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ near.ai/qwen2p5-coder-32b-instruct/1.0.0       │ hyperbolic::Qwen/Qwen2.5-Coder-32B-Instruct & fire │
│                                                │ works::accounts/fireworks/models/qwen2p5-coder-    │
│                                                │ 32b-instruct                                       │
├────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ near.ai/qwq-32b-preview/1.0.0                  │ hyperbolic::Qwen/QwQ-32B-Preview &                 │
│                                                │ fireworks::accounts/fireworks/models/qwen-         │
│                                                │ qwq-32b-preview                                    │
├────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ near.ai/flux-1-schnell-fp8/1.0.0               │ fireworks::accounts/fireworks/models/flux-1-       │
│                                                │ schnell-fp8                                        │
├────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ near.ai/flux-1-dev-fp8/1.0.0                   │ fireworks::accounts/fireworks/models/flux-1-dev-   │
│                                                │ fp8                                                │
├────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ near.ai/stable-diffusion-3p5-medium/1.0.0      │ fireworks::accounts/fireworks/models/stable-       │
│                                                │ diffusion-3p5-medium                               │
├────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ near.ai/stable-diffusion-3p5-large/1.0.0       │ fireworks::accounts/fireworks/models/stable-       │
│                                                │ diffusion-3p5-large                                │
├────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
│ near.ai/stable-diffusion-3p5-large-turbo/1.0.0 │ fireworks::accounts/fireworks/models/stable-       │
│                                                │ diffusion-3p5-large-turbo                          │
└────────────────────────────────────────────────┴────────────────────────────────────────────────────┘
Please verify, then repeat the command with --dry_run=False
```