### PR TITLE
Use dataset_evaluation_name if present with mbpp and mmlu

### DIFF
--- a/nearai/solvers/mbpp_solver.py
+++ b/nearai/solvers/mbpp_solver.py
@@ -76,7 +76,8 @@ class MBPPSolverStrategy(SolverStrategy):
         self.shots = shots
 
     def evaluation_name(self) -> str:  # noqa: D102
-        return f"mbpp_{self.shots}shots"
+        prefix = self.dataset_evaluation_name if self.dataset_evaluation_name else "mbpp"
+        return f"{prefix}_{self.shots}shots"
 
     def compatible_datasets(self) -> List[str]:  # noqa: D102
         return ["mbpp"]

--- a/nearai/solvers/mmlu_solver.py
+++ b/nearai/solvers/mmlu_solver.py
@@ -26,7 +26,8 @@ class MMLUSolverStrategy(SolverStrategy):
         self.shots = shots
 
     def evaluation_name(self) -> str:  # noqa: D102
-        return f"mmlu_{self.shots}shots"
+        prefix = self.dataset_evaluation_name if self.dataset_evaluation_name else "mmlu"
+        return f"{prefix}_{self.shots}shots"
 
     def compatible_datasets(self) -> List[str]:  # noqa: D102
         return ["mmlu"]


### PR DESCRIPTION
It will be useful to have some fast benchmarks, so that we can determine quickly if the entry is worth being evaluated on more time consuming benchmarks.
I want to add 100 samples benchmark datasets for mbpp and mmlu. I will call them `mbpp_100samples` and `mmlu_100samples`

`dataset_evaluation_name` is already being used by LeanSolver: [link](https://github.com/nearai/nearai/blob/507a4c63e3c99bbb0a2f02d79bb18b1fb4088ac2/nearai/solvers/lean_solver.py#L132)