### PR TITLE
Remove 'open' lines from quickstart as they may cause unexpected behavior

### DIFF
--- a/docs/agent_quickstart.sh
+++ b/docs/agent_quickstart.sh
@@ -3,8 +3,8 @@
 mkdir -p ~/.nearai/registry/user/example_agent/0.0.1
 nearai registry metadata_template ~/.nearai/registry/user/example_agent/0.0.1 agent --description="Where would you like to travel?"
 cat docs/examples/example_agent.py > ~/.nearai/registry/user/example_agent/0.0.1/agent.py
-open ~/.nearai/registry/user/example_agent/0.0.1/metadata.json
-open ~/.nearai/registry/user/example_agent/0.0.1/agent.py
+echo "Consider editing ~/.nearai/registry/user/example_agent/0.0.1/metadata.json"
+echo "Consider editing ~/.nearai/registry/user/example_agent/0.0.1/agent.py"
 echo "Starting example_agent in interactive mode..."
 echo "\t type 'exit' to quit."
 nearai agent interactive ~/.nearai/registry/user/example_agent/0.0.1 --local


### PR DESCRIPTION
With `$ open ...` lines the script execution depends on file associations or system settings. That may cause unexpected or irritating behavior. For example, it caused `IDLE Shell` to open up, with a script failing.