### PR TITLE
Make default agent interactive

### DIFF
--- a/nearai/cli.py
+++ b/nearai/cli.py
@@ -720,12 +720,10 @@ class AgentCli:
 
 
 def run(env: Environment):
-    env.add_message("assistant", "Hello, world!")
     # Your agent code here
-    # Example:
-    # prompt = {"role": "system", "content": "You are a helpful assistant."}
-    # result = env.completion([prompt] + env.list_messages())
-    # env.add_message("assistant", result)
+    prompt = {"role": "system", "content": "You are a helpful assistant."}
+    result = env.completion([prompt] + env.list_messages())
+    env.add_message("assistant", result)
 
 
 run(env)


### PR DESCRIPTION
The current agent only replies "Hello, World" to any prompt given by the user. This makes it look like `nearai` agents are broken, since the user will see a lot of things happening in the console, but they will always get the same answer

In this commit, I have modified the default agent so it is interactive by default

This effectively allows us to greatly reduce the "time to first wow" by a lot in the quickstart tutorial, besides not making the `nearai` look like it is broken

This tackles issue #636 