### PR TITLE
Forks - DB table for tracking

### DIFF
--- a/hub/alembic/versions/7255ee296766_create_fork_table.py
+++ b/hub/alembic/versions/7255ee296766_create_fork_table.py
@@ -1,0 +1,33 @@
+"""Create fork table.
+
+Revision ID: 7255ee296766
+Revises: e7197522ba61
+Create Date: 2024-12-13 09:44:03.353472
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7255ee296766"
+down_revision: Union[str, None] = "e7197522ba61"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "forks",
+        sa.Column("category", sa.String(255), primary_key=True),
+        sa.Column("from_namespace", sa.String(255), nullable=False),
+        sa.Column("from_name", sa.String(255), nullable=False),
+        sa.Column("to_namespace", sa.String(255), primary_key=True),
+        sa.Column("to_name", sa.String(255), primary_key=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("forks")

--- a/hub/api/v1/models.py
+++ b/hub/api/v1/models.py
@@ -112,6 +112,16 @@ class Stars(SQLModel, table=True):
     name: str = Field(primary_key=True)
 
 
+class Fork(SQLModel, table=True):
+    __tablename__ = "forks"
+
+    category: str = Field(primary_key=True)
+    from_namespace: str = Field(nullable=False)
+    from_name: str = Field(nullable=False)
+    to_namespace: str = Field(primary_key=True)
+    to_name: str = Field(primary_key=True)
+
+
 class Job(SQLModel, table=True):
     __tablename__ = "jobs"
 

--- a/hub/demo/src/app/agents/[namespace]/[name]/[version]/page.tsx
+++ b/hub/demo/src/app/agents/[namespace]/[name]/[version]/page.tsx
@@ -1,30 +1,12 @@
 'use client';
 
-import { Badge, Flex, Section } from '@near-pagoda/ui';
-
-import { Markdown } from '~/components/lib/Markdown';
+import { EntryOverview } from '~/components/EntryOverview';
 import { useCurrentEntry } from '~/hooks/entries';
 
-export default function EntryDetailsPage() {
+export default function EntryOverviewPage() {
   const { currentEntry } = useCurrentEntry('agent');
 
   if (!currentEntry) return null;
 
-  return (
-    <>
-      <Section>
-        <Markdown
-          content={currentEntry.description || 'No description provided.'}
-        />
-
-        {currentEntry.tags.length > 0 && (
-          <Flex gap="s" wrap="wrap">
-            {currentEntry.tags.map((tag) => (
-              <Badge label={tag} variant="neutral" key={tag} />
-            ))}
-          </Flex>
-        )}
-      </Section>
-    </>
-  );
+  return <EntryOverview entry={currentEntry} />;
 }

--- a/hub/demo/src/app/benchmarks/[namespace]/[name]/[version]/page.tsx
+++ b/hub/demo/src/app/benchmarks/[namespace]/[name]/[version]/page.tsx
@@ -1,29 +1,12 @@
 'use client';
 
-import { Badge, Flex, Section, Text } from '@near-pagoda/ui';
-
+import { EntryOverview } from '~/components/EntryOverview';
 import { useCurrentEntry } from '~/hooks/entries';
 
-export default function EntryDetailsPage() {
+export default function EntryOverviewPage() {
   const { currentEntry } = useCurrentEntry('benchmark');
 
   if (!currentEntry) return null;
 
-  return (
-    <>
-      <Section>
-        <Text size="text-l">Description</Text>
-
-        <Text>{currentEntry.description || 'No description provided.'}</Text>
-
-        {currentEntry.tags.length > 0 && (
-          <Flex gap="s" wrap="wrap">
-            {currentEntry.tags.map((tag) => (
-              <Badge label={tag} variant="neutral" key={tag} />
-            ))}
-          </Flex>
-        )}
-      </Section>
-    </>
-  );
+  return <EntryOverview entry={currentEntry} />;
 }

--- a/hub/demo/src/app/datasets/[namespace]/[name]/[version]/page.tsx
+++ b/hub/demo/src/app/datasets/[namespace]/[name]/[version]/page.tsx
@@ -1,29 +1,12 @@
 'use client';
 
-import { Badge, Flex, Section, Text } from '@near-pagoda/ui';
-
+import { EntryOverview } from '~/components/EntryOverview';
 import { useCurrentEntry } from '~/hooks/entries';
 
-export default function EntryDetailsPage() {
+export default function EntryOverviewPage() {
   const { currentEntry } = useCurrentEntry('dataset');
 
   if (!currentEntry) return null;
 
-  return (
-    <>
-      <Section>
-        <Text size="text-l">Description</Text>
-
-        <Text>{currentEntry.description || 'No description provided.'}</Text>
-
-        {currentEntry.tags.length > 0 && (
-          <Flex gap="s" wrap="wrap">
-            {currentEntry.tags.map((tag) => (
-              <Badge label={tag} variant="neutral" key={tag} />
-            ))}
-          </Flex>
-        )}
-      </Section>
-    </>
-  );
+  return <EntryOverview entry={currentEntry} />;
 }

--- a/hub/demo/src/app/models/[namespace]/[name]/[version]/page.tsx
+++ b/hub/demo/src/app/models/[namespace]/[name]/[version]/page.tsx
@@ -1,29 +1,12 @@
 'use client';
 
-import { Badge, Flex, Section, Text } from '@near-pagoda/ui';
-
+import { EntryOverview } from '~/components/EntryOverview';
 import { useCurrentEntry } from '~/hooks/entries';
 
-export default function EntryDetailsPage() {
+export default function EntryOverviewPage() {
   const { currentEntry } = useCurrentEntry('model');
 
   if (!currentEntry) return null;
 
-  return (
-    <>
-      <Section>
-        <Text size="text-l">Description</Text>
-
-        <Text>{currentEntry.description || 'No description provided.'}</Text>
-
-        {currentEntry.tags.length > 0 && (
-          <Flex gap="s" wrap="wrap">
-            {currentEntry.tags.map((tag) => (
-              <Badge label={tag} variant="neutral" key={tag} />
-            ))}
-          </Flex>
-        )}
-      </Section>
-    </>
-  );
+  return <EntryOverview entry={currentEntry} />;
 }

--- a/hub/demo/src/components/EntriesTable.tsx
+++ b/hub/demo/src/components/EntriesTable.tsx
@@ -96,9 +96,16 @@ export const EntriesTable = ({ category, title }: Props) => {
             <Table.HeadCell
               column="num_stars"
               sortable
-              style={{ paddingLeft: '1.4rem' }}
+              style={{ paddingLeft: '1rem' }}
             >
               Stars
+            </Table.HeadCell>
+            <Table.HeadCell
+              column="num_forks"
+              sortable
+              style={{ paddingLeft: '1rem' }}
+            >
+              Forks
             </Table.HeadCell>
             <Table.HeadCell />
           </Table.Row>
@@ -159,9 +166,11 @@ export const EntriesTable = ({ category, title }: Props) => {
               </Table.Cell>
 
               <Table.Cell style={{ width: '1px' }}>
-                <Flex align="center" gap="xs">
-                  <ForkButton entry={entry} variant="simple" />
+                <ForkButton entry={entry} variant="simple" />
+              </Table.Cell>
 
+              <Table.Cell style={{ width: '1px' }}>
+                <Flex align="center" gap="xs">
                   {!env.NEXT_PUBLIC_CONSUMER_MODE && (
                     <>
                       {benchmarkEvaluationsUrlForEntry(entry) && (

--- a/hub/demo/src/components/EntriesTable.tsx
+++ b/hub/demo/src/components/EntriesTable.tsx
@@ -14,6 +14,7 @@ import {
 } from '@near-pagoda/ui';
 import { ChatCircleDots, CodeBlock, Play } from '@phosphor-icons/react';
 import { format, formatDistanceToNow } from 'date-fns';
+import { type ReactNode } from 'react';
 
 import { env } from '~/env';
 import { useEntriesSearch } from '~/hooks/entries';
@@ -30,12 +31,24 @@ import { ForkButton } from './ForkButton';
 import { StarButton } from './StarButton';
 
 type Props = {
+  bleed?: boolean;
   category: EntryCategory;
+  header?: ReactNode;
+  forkOf?: {
+    name: string;
+    namespace: string;
+  };
   title: string;
 };
 
-export const EntriesTable = ({ category, title }: Props) => {
-  const entriesQuery = api.hub.entries.useQuery({ category });
+export const EntriesTable = ({
+  bleed,
+  category,
+  forkOf,
+  header,
+  title,
+}: Props) => {
+  const entriesQuery = api.hub.entries.useQuery({ category, forkOf });
 
   const { searched, searchQuery, setSearchQuery } = useEntriesSearch(
     entriesQuery.data,
@@ -48,21 +61,23 @@ export const EntriesTable = ({ category, title }: Props) => {
   });
 
   return (
-    <Section>
+    <Section bleed={bleed} padding={bleed ? 'none' : undefined}>
       <Grid
         columns="1fr 20rem"
         align="center"
         gap="m"
         phone={{ columns: '1fr' }}
       >
-        <Text as="h1" size="text-2xl">
-          {title}{' '}
-          {entriesQuery.data && (
-            <Text as="span" size="text-2xl" color="sand-10" weight={400}>
-              ({entriesQuery.data.length})
-            </Text>
-          )}
-        </Text>
+        {header || (
+          <Text as="h1" size="text-2xl">
+            {title}{' '}
+            {entriesQuery.data && (
+              <Text as="span" size="text-2xl" color="sand-10" weight={400}>
+                ({entriesQuery.data.length})
+              </Text>
+            )}
+          </Text>
+        )}
 
         <Input
           type="search"
@@ -73,162 +88,175 @@ export const EntriesTable = ({ category, title }: Props) => {
         />
       </Grid>
 
-      <Table.Root
-        {...tableProps}
-        setSort={(value) => {
-          void entriesQuery.refetch();
-          tableProps.setSort(value);
-        }}
-      >
-        <Table.Head>
-          <Table.Row>
-            <Table.HeadCell column="name" sortable>
-              Name
-            </Table.HeadCell>
-            <Table.HeadCell column="namespace" sortable>
-              Creator
-            </Table.HeadCell>
-            <Table.HeadCell>Version</Table.HeadCell>
-            <Table.HeadCell column="updated" sortable>
-              Updated
-            </Table.HeadCell>
-            <Table.HeadCell>Tags</Table.HeadCell>
-            <Table.HeadCell
-              column="num_stars"
-              sortable
-              style={{ paddingLeft: '1rem' }}
-            >
-              Stars
-            </Table.HeadCell>
-            <Table.HeadCell
-              column="num_forks"
-              sortable
-              style={{ paddingLeft: '1rem' }}
-            >
-              Forks
-            </Table.HeadCell>
-            <Table.HeadCell />
-          </Table.Row>
-        </Table.Head>
-
-        <Table.Body>
-          {!sorted && <Table.PlaceholderRows />}
-
-          {sorted?.map((entry, index) => (
-            <Table.Row key={index}>
-              <Table.Cell
-                href={primaryUrlForEntry(entry)}
-                style={{ minWidth: '10rem', maxWidth: '20rem' }}
+      {sorted?.length === 0 ? (
+        <>
+          {searchQuery && (
+            <Text>No matches found. Try a different search?</Text>
+          )}
+          {!searchQuery && entriesQuery.data?.length === 0 && (
+            <Text>No {title.toLowerCase()} exist yet.</Text>
+          )}
+        </>
+      ) : (
+        <Table.Root
+          {...tableProps}
+          setSort={(value) => {
+            void entriesQuery.refetch();
+            tableProps.setSort(value);
+          }}
+        >
+          <Table.Head>
+            <Table.Row>
+              <Table.HeadCell column="name" sortable>
+                Name
+              </Table.HeadCell>
+              <Table.HeadCell column="namespace" sortable>
+                Creator
+              </Table.HeadCell>
+              <Table.HeadCell>Version</Table.HeadCell>
+              <Table.HeadCell column="updated" sortable>
+                Updated
+              </Table.HeadCell>
+              <Table.HeadCell>Tags</Table.HeadCell>
+              <Table.HeadCell
+                column="num_stars"
+                sortable
+                style={{ paddingLeft: '1rem' }}
               >
-                <Flex direction="column">
-                  <Text size="text-s" weight={600} color="sand-12">
-                    {entry.name}
-                  </Text>
-                  <Text size="text-xs" clampLines={1}>
-                    {entry.description}
-                  </Text>
-                </Flex>
-              </Table.Cell>
-
-              <Table.Cell
-                href={`/profiles/${entry.namespace}`}
-                style={{ minWidth: '8rem', maxWidth: '12rem' }}
+                Stars
+              </Table.HeadCell>
+              <Table.HeadCell
+                column="num_forks"
+                sortable
+                style={{ paddingLeft: '1rem' }}
               >
-                <Text size="text-s" color="sand-12" clampLines={1}>
-                  {entry.namespace}
-                </Text>
-              </Table.Cell>
-
-              <Table.Cell>
-                <Text size="text-s">{entry.version}</Text>
-              </Table.Cell>
-
-              <Table.Cell>
-                <Text size="text-xs">
-                  <Tooltip content={format(entry.updated, 'PPpp')}>
-                    <span>
-                      {formatDistanceToNow(entry.updated, { addSuffix: true })}
-                    </span>
-                  </Tooltip>
-                </Text>
-              </Table.Cell>
-
-              <Table.Cell style={{ maxWidth: '14rem', overflow: 'hidden' }}>
-                <Flex gap="xs">
-                  {entry.tags.map((tag) => (
-                    <Badge label={tag} variant="neutral" key={tag} />
-                  ))}
-                </Flex>
-              </Table.Cell>
-
-              <Table.Cell style={{ width: '1px' }}>
-                <StarButton entry={entry} variant="simple" />
-              </Table.Cell>
-
-              <Table.Cell style={{ width: '1px' }}>
-                <ForkButton entry={entry} variant="simple" />
-              </Table.Cell>
-
-              <Table.Cell style={{ width: '1px' }}>
-                <Flex align="center" gap="xs">
-                  {!env.NEXT_PUBLIC_CONSUMER_MODE && (
-                    <>
-                      {benchmarkEvaluationsUrlForEntry(entry) && (
-                        <Tooltip asChild content="View evaluations">
-                          <Button
-                            label="View evaluations"
-                            icon={ENTRY_CATEGORY_LABELS.evaluation.icon}
-                            size="small"
-                            fill="ghost"
-                            href={benchmarkEvaluationsUrlForEntry(entry)}
-                          />
-                        </Tooltip>
-                      )}
-
-                      {sourceUrlForEntry(entry) && (
-                        <Tooltip asChild content="View source">
-                          <Button
-                            label="View source"
-                            icon={<CodeBlock weight="duotone" />}
-                            size="small"
-                            fill="ghost"
-                            href={sourceUrlForEntry(entry)}
-                          />
-                        </Tooltip>
-                      )}
-                    </>
-                  )}
-
-                  {category === 'agent' && (
-                    <Tooltip
-                      asChild
-                      content={
-                        env.NEXT_PUBLIC_CONSUMER_MODE
-                          ? 'Chat with agent'
-                          : 'Run agent'
-                      }
-                    >
-                      <Button
-                        label="Run agent"
-                        icon={
-                          env.NEXT_PUBLIC_CONSUMER_MODE ? (
-                            <ChatCircleDots weight="duotone" />
-                          ) : (
-                            <Play weight="duotone" />
-                          )
-                        }
-                        size="small"
-                        fill="ghost"
-                        href={`${primaryUrlForEntry(entry)}/run`}
-                      />
-                    </Tooltip>
-                  )}
-                </Flex>
-              </Table.Cell>
+                Forks
+              </Table.HeadCell>
+              <Table.HeadCell />
             </Table.Row>
-          ))}
-        </Table.Body>
-      </Table.Root>
+          </Table.Head>
+
+          <Table.Body>
+            {!sorted && <Table.PlaceholderRows />}
+
+            {sorted?.map((entry, index) => (
+              <Table.Row key={index}>
+                <Table.Cell
+                  href={primaryUrlForEntry(entry)}
+                  style={{ minWidth: '10rem', maxWidth: '20rem' }}
+                >
+                  <Flex direction="column">
+                    <Text size="text-s" weight={600} color="sand-12">
+                      {entry.name}
+                    </Text>
+                    <Text size="text-xs" clampLines={1}>
+                      {entry.description}
+                    </Text>
+                  </Flex>
+                </Table.Cell>
+
+                <Table.Cell
+                  href={`/profiles/${entry.namespace}`}
+                  style={{ minWidth: '8rem', maxWidth: '12rem' }}
+                >
+                  <Text size="text-s" color="sand-12" clampLines={1}>
+                    {entry.namespace}
+                  </Text>
+                </Table.Cell>
+
+                <Table.Cell>
+                  <Text size="text-s">{entry.version}</Text>
+                </Table.Cell>
+
+                <Table.Cell>
+                  <Text size="text-xs">
+                    <Tooltip content={format(entry.updated, 'PPpp')}>
+                      <span>
+                        {formatDistanceToNow(entry.updated, {
+                          addSuffix: true,
+                        })}
+                      </span>
+                    </Tooltip>
+                  </Text>
+                </Table.Cell>
+
+                <Table.Cell style={{ maxWidth: '14rem', overflow: 'hidden' }}>
+                  <Flex gap="xs">
+                    {entry.tags.map((tag) => (
+                      <Badge label={tag} variant="neutral" key={tag} />
+                    ))}
+                  </Flex>
+                </Table.Cell>
+
+                <Table.Cell style={{ width: '1px' }}>
+                  <StarButton entry={entry} variant="simple" />
+                </Table.Cell>
+
+                <Table.Cell style={{ width: '1px' }}>
+                  <ForkButton entry={entry} variant="simple" />
+                </Table.Cell>
+
+                <Table.Cell style={{ width: '1px' }}>
+                  <Flex align="center" gap="xs">
+                    {!env.NEXT_PUBLIC_CONSUMER_MODE && (
+                      <>
+                        {benchmarkEvaluationsUrlForEntry(entry) && (
+                          <Tooltip asChild content="View evaluations">
+                            <Button
+                              label="View evaluations"
+                              icon={ENTRY_CATEGORY_LABELS.evaluation.icon}
+                              size="small"
+                              fill="ghost"
+                              href={benchmarkEvaluationsUrlForEntry(entry)}
+                            />
+                          </Tooltip>
+                        )}
+
+                        {sourceUrlForEntry(entry) && (
+                          <Tooltip asChild content="View source">
+                            <Button
+                              label="View source"
+                              icon={<CodeBlock weight="duotone" />}
+                              size="small"
+                              fill="ghost"
+                              href={sourceUrlForEntry(entry)}
+                            />
+                          </Tooltip>
+                        )}
+                      </>
+                    )}
+
+                    {category === 'agent' && (
+                      <Tooltip
+                        asChild
+                        content={
+                          env.NEXT_PUBLIC_CONSUMER_MODE
+                            ? 'Chat with agent'
+                            : 'Run agent'
+                        }
+                      >
+                        <Button
+                          label="Run agent"
+                          icon={
+                            env.NEXT_PUBLIC_CONSUMER_MODE ? (
+                              <ChatCircleDots weight="duotone" />
+                            ) : (
+                              <Play weight="duotone" />
+                            )
+                          }
+                          size="small"
+                          fill="ghost"
+                          href={`${primaryUrlForEntry(entry)}/run`}
+                        />
+                      </Tooltip>
+                    )}
+                  </Flex>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+      )}
     </Section>
   );
 };

--- a/hub/demo/src/components/EntryDetailsLayout.tsx
+++ b/hub/demo/src/components/EntryDetailsLayout.tsx
@@ -12,7 +12,7 @@ import {
   Text,
   Tooltip,
 } from '@near-pagoda/ui';
-import { CaretDown, LockKey } from '@phosphor-icons/react';
+import { CaretDown, GitFork, LockKey } from '@phosphor-icons/react';
 import { usePathname, useRouter } from 'next/navigation';
 import { type ReactElement, type ReactNode, useEffect } from 'react';
 
@@ -20,7 +20,7 @@ import { ErrorSection } from '~/components/ErrorSection';
 import { StarButton } from '~/components/StarButton';
 import { env } from '~/env';
 import { useCurrentEntry, useEntryParams } from '~/hooks/entries';
-import { ENTRY_CATEGORY_LABELS } from '~/lib/entries';
+import { ENTRY_CATEGORY_LABELS, primaryUrlForEntry } from '~/lib/entries';
 import { type EntryCategory } from '~/lib/models';
 
 import { DevelopButton } from './DevelopButton';
@@ -175,6 +175,35 @@ export const EntryDetailsLayout = ({
                       </Dropdown.Section>
                     </Dropdown.Content>
                   </Dropdown.Root>
+
+                  {currentEntry?.fork_of && (
+                    <Tooltip
+                      content={
+                        <Text size="text-xs" color="current">
+                          This {category} is a fork of{' '}
+                          <Text
+                            size="text-xs"
+                            href={primaryUrlForEntry({
+                              category: currentEntry.category,
+                              namespace: currentEntry.fork_of.namespace,
+                              name: currentEntry.fork_of.name,
+                            })}
+                          >
+                            {currentEntry.fork_of.namespace}/
+                            {currentEntry.fork_of.name}
+                          </Text>
+                        </Text>
+                      }
+                      root={{ disableHoverableContent: false }}
+                    >
+                      <SvgIcon
+                        icon={<GitFork weight="fill" />}
+                        size="xs"
+                        color="sand-9"
+                        style={{ cursor: 'help' }}
+                      />
+                    </Tooltip>
+                  )}
 
                   {currentEntry?.details.private_source && (
                     <Tooltip

--- a/hub/demo/src/components/EntryOverview.tsx
+++ b/hub/demo/src/components/EntryOverview.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Badge, Flex, Grid, Section, Text } from '@near-pagoda/ui';
+import { type z } from 'zod';
+
+import { type entryModel } from '~/lib/models';
+
+import { ForkButton } from './ForkButton';
+import { Markdown } from './lib/Markdown';
+
+type Props = {
+  entry: z.infer<typeof entryModel>;
+};
+
+export const EntryOverview = ({ entry }: Props) => {
+  return (
+    <Grid
+      columns="1fr 1fr"
+      align="stretch"
+      style={{ flexGrow: 1 }}
+      tablet={{ columns: '1fr' }}
+    >
+      <Section background="sand-2" gap="m" bleed>
+        <Text size="text-l">Description</Text>
+
+        <Markdown
+          content={
+            entry.description ||
+            `No description provided for this ${entry.category}.`
+          }
+        />
+
+        {entry.tags.length > 0 && (
+          <Flex gap="s" wrap="wrap">
+            {entry.tags.map((tag) => (
+              <Badge label={tag} variant="neutral" key={tag} />
+            ))}
+          </Flex>
+        )}
+      </Section>
+
+      <Section background="sand-1" gap="m" bleed>
+        <Flex align="center" gap="s">
+          <Text size="text-l">Forks</Text>
+          <ForkButton entry={entry} variant="simple" />
+        </Flex>
+
+        <Text color="sand-10" size="text-s">
+          This {entry.category} {`hasn't`} been forked yet.
+        </Text>
+
+        {/* TODO: Create endpoint for fetching all forks of entry */}
+        {/* TODO: Update all other overview pages for models, datasets, etc */}
+        {/* <EntryCard entry={currentEntry} /> */}
+      </Section>
+    </Grid>
+  );
+};

--- a/hub/demo/src/components/EntryOverview.tsx
+++ b/hub/demo/src/components/EntryOverview.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { Badge, Flex, Grid, Section, Text } from '@near-pagoda/ui';
+import { Badge, Flex, Section, Text } from '@near-pagoda/ui';
 import { type z } from 'zod';
 
 import { type entryModel } from '~/lib/models';
 
+import { EntriesTable } from './EntriesTable';
 import { ForkButton } from './ForkButton';
 import { Markdown } from './lib/Markdown';
 
@@ -14,13 +15,8 @@ type Props = {
 
 export const EntryOverview = ({ entry }: Props) => {
   return (
-    <Grid
-      columns="1fr 1fr"
-      align="stretch"
-      style={{ flexGrow: 1 }}
-      tablet={{ columns: '1fr' }}
-    >
-      <Section background="sand-2" gap="m" bleed>
+    <>
+      <Section background="sand-2">
         <Text size="text-l">Description</Text>
 
         <Markdown
@@ -39,20 +35,20 @@ export const EntryOverview = ({ entry }: Props) => {
         )}
       </Section>
 
-      <Section background="sand-1" gap="m" bleed>
-        <Flex align="center" gap="s">
-          <Text size="text-l">Forks</Text>
-          <ForkButton entry={entry} variant="simple" />
-        </Flex>
-
-        <Text color="sand-10" size="text-s">
-          This {entry.category} {`hasn't`} been forked yet.
-        </Text>
-
-        {/* TODO: Create endpoint for fetching all forks of entry */}
-        {/* TODO: Update all other overview pages for models, datasets, etc */}
-        {/* <EntryCard entry={currentEntry} /> */}
-      </Section>
-    </Grid>
+      <EntriesTable
+        category={entry.category}
+        header={
+          <Flex align="center" gap="s">
+            <Text size="text-l">Forks</Text>
+            <ForkButton entry={entry} variant="simple" />
+          </Flex>
+        }
+        forkOf={{
+          name: entry.name,
+          namespace: entry.namespace,
+        }}
+        title="Forks"
+      />
+    </>
   );
 };

--- a/hub/demo/src/components/EntrySource.tsx
+++ b/hub/demo/src/components/EntrySource.tsx
@@ -7,7 +7,6 @@ import {
   CardList,
   Container,
   Flex,
-  PlaceholderCard,
   PlaceholderStack,
   Section,
   SvgIcon,
@@ -163,7 +162,7 @@ export const EntrySource = ({ entry }: Props) => {
                   language={filePathToCodeLanguage(openedFile.path)}
                 />
               ) : (
-                <PlaceholderCard />
+                <PlaceholderStack />
               )}
             </>
           )}

--- a/hub/demo/src/components/ForkButton.tsx
+++ b/hub/demo/src/components/ForkButton.tsx
@@ -37,6 +37,7 @@ export const ForkButton = ({ entry, style, variant = 'simple' }: Props) => {
   const isPermittedToViewSource =
     !entry?.details.private_source || accountId === entry.namespace;
   const [forkModalIsOpen, setForkModalIsOpen] = useState(false);
+  const count = entry?.num_forks ?? 0;
 
   const fork = () => setForkModalIsOpen(true);
 
@@ -44,20 +45,29 @@ export const ForkButton = ({ entry, style, variant = 'simple' }: Props) => {
 
   return (
     <>
-      <Tooltip asChild content={`Fork this ${entry?.category ?? 'agent'}`}>
+      <Tooltip
+        asChild
+        content={`Create your own copy of this ${entry?.category ?? 'agent'}`}
+      >
         {variant === 'simple' ? (
           <Button
-            label="Fork"
-            icon={<SvgIcon size="xs" icon={<GitFork weight="duotone" />} />}
+            label={count.toString()}
+            iconLeft={<SvgIcon size="xs" icon={<GitFork weight="duotone" />} />}
             size="small"
+            variant="secondary"
             fill="ghost"
             onClick={fork}
-            style={style}
+            style={{
+              ...style,
+              fontVariantNumeric: 'tabular-nums',
+              paddingInline: 'var(--gap-s)',
+            }}
           />
         ) : (
           <Button
             label="Fork"
             iconLeft={<SvgIcon size="xs" icon={<GitFork />} />}
+            count={count}
             size="small"
             fill="outline"
             onClick={fork}
@@ -142,6 +152,7 @@ const ForkForm = ({ entry, onFinish }: ForkFormProps) => {
       });
 
       await utils.hub.entries.refetch();
+
       router.push(primaryUrlForEntry(result.entry)!);
 
       openToast({
@@ -157,6 +168,7 @@ const ForkForm = ({ entry, onFinish }: ForkFormProps) => {
   };
 
   const findConflictingEntry = (name: string) => {
+    if (form.formState.isSubmitting) return;
     const match = entriesQuery.data?.find((entry) => entry.name === name);
     return match;
   };

--- a/hub/demo/src/components/StarButton.tsx
+++ b/hub/demo/src/components/StarButton.tsx
@@ -100,10 +100,15 @@ export const StarButton = ({ entry, style, variant = 'simple' }: Props) => {
         variant={variant === 'simple' ? 'secondary' : 'primary'}
         fill={variant === 'simple' ? 'ghost' : 'outline'}
         onClick={toggleStar}
-        style={{
-          ...style,
-          fontVariantNumeric: 'tabular-nums',
-        }}
+        style={
+          variant === 'simple'
+            ? {
+                ...style,
+                fontVariantNumeric: 'tabular-nums',
+                paddingInline: 'var(--gap-s)',
+              }
+            : style
+        }
         className={s.starButton}
         data-clicked={clicked}
         data-starred={visuallyStarred}

--- a/hub/demo/src/components/lib/Sidebar/Sidebar.module.scss
+++ b/hub/demo/src/components/lib/Sidebar/Sidebar.module.scss
@@ -53,10 +53,7 @@
   max-height: var(--section-fill-height);
   min-height: 0;
   flex-shrink: 0;
-  box-shadow:
-    0 0 1rem rgba(0, 0, 0, 0.1),
-    -1px 0 0 var(--sand-4),
-    1px 0 0 var(--sand-4);
+  box-shadow: 0 0 1rem rgba(0, 0, 0, 0.1);
 
   @media (max-width: $tabletBreakpointMaxWidth) {
     position: fixed;

--- a/hub/demo/src/lib/models.ts
+++ b/hub/demo/src/lib/models.ts
@@ -122,8 +122,15 @@ export const entryModel = z.object({
   tags: z.string().array().default([]),
   show_entry: z.boolean().default(true),
   starred_by_point_of_view: z.boolean().default(false),
+  num_forks: z.number().default(0),
   num_stars: z.number().default(0),
   details: entryDetailsModel.default({}),
+  fork_of: z
+    .object({
+      name: z.string(),
+      namespace: z.string(),
+    })
+    .nullish(),
 });
 
 export const entriesModel = z.array(entryModel);

--- a/hub/demo/src/server/api/routers/hub.ts
+++ b/hub/demo/src/server/api/routers/hub.ts
@@ -39,6 +39,12 @@ export const hubRouter = createTRPCRouter({
     .input(
       z.object({
         category: entryCategory.optional(),
+        forkOf: z
+          .object({
+            name: z.string(),
+            namespace: z.string(),
+          })
+          .optional(),
         limit: z.number().default(10_000),
         namespace: z.string().optional(),
         showLatestVersion: z.boolean().default(true),
@@ -71,8 +77,12 @@ export const hubRouter = createTRPCRouter({
         return await loadEntriesFromDirectory(registryPath);
       }
 
-      if (input.starredBy) {
+      if (input.starredBy)
         url.searchParams.append('starred_by', input.starredBy);
+
+      if (input.forkOf) {
+        url.searchParams.append('fork_of_namespace', input.forkOf.namespace);
+        url.searchParams.append('fork_of_name', input.forkOf.name);
       }
 
       if (ctx.signature) {


### PR DESCRIPTION
- Added `forks` DB table to track forks
- Display fork count on all fork buttons (just like the star button)
- Display all forks of an entry on its detail overview page
- Show fork icon with tooltip next to entry title to indicate when an entry is a fork of another entry

NOTE: The SQL inside `list_entries_inner` probably needs a good refactoring from someone more experienced than myself at some point.

<img width="1318" alt="Screenshot 2024-12-16 at 10 13 10 AM" src="https://github.com/user-attachments/assets/8600978c-03c5-4515-b675-45d7db548ba0" />

<img width="585" alt="Screenshot 2024-12-16 at 10 13 19 AM" src="https://github.com/user-attachments/assets/1276e4a2-369e-4fc1-bb6a-245b12ea6897" />
