### PR TITLE
new_message param is only used by benchmarking

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -291,24 +291,6 @@ If you do not want to use the built-in tools, use `get_tool_registry(new=True)`
 
 ⚠️ You can't remove or overwrite a file once it's uploaded, but you can hide the entire agent by setting the `"show_entry": false` field.
 
-## Running an agent remotely through the CLI
-Agents can be run through the CLI using the `nearai agent run_remote` command.
-A new message can be passed with the new_message argument. A starting environment (state) can be passed with the environment_id argument.
-
-```shell
-  nearai agent run_remote flatirons.near/example-travel-agent/1 \
-  new_message="I would like to travel to Brazil"
-```
-
-This environment already contains a request to travel to Paris and an agent response.
-A new_message could be included to further refine the request. In this example without a new_message the agent will
-reprocess the previous response and follow up about travel to Paris.
-
-```shell
-  nearai agent run_remote flatirons.near/example-travel-agent/1 \
-  environment_id="flatirons.near/environment_run_flatirons.near_example-travel-agent_1_1c82938c55fc43e492882ee938c6356a/0"
-```
-
 ## Running an agent through the API
 Agents can be run through the `/thread/runs`, `/thread/{thread_id}/runs` or  `/agent/runs` endpoints. The /thread syntax
 matches the OpenAI / LangGraph API. The /agent syntax is NearAI specific.

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,7 +145,6 @@ See the [Agents](agents.md) documentation and How to guide
     * [Additional environment methods](agents.md#additional-environment-methods)
     * [Tool registry](agents.md#tool-registry-and-function-tool-calling)
 * [Uploading an agent](agents.md#uploading-an-agent)
-* [Running an agent remotely through the CLI](agents.md#running-an-agent-remotely-through-the-cli)
 * [Running an agent through the API](agents.md#running-an-agent-through-the-api)
 * [Remote results](agents.md#remote-results)
     * [Signed messages](agents.md#signed-messages)

--- a/hub/api/v1/thread_routes.py
+++ b/hub/api/v1/thread_routes.py
@@ -628,7 +628,7 @@ def run_agent(
         if runner == "custom_runner":
             custom_runner_url = getenv("CUSTOM_RUNNER_URL", None)
             if custom_runner_url:
-                invoke_agent_via_url(custom_runner_url, agents, thread_id, run_id, auth, "", params)
+                invoke_agent_via_url(custom_runner_url, agents, thread_id, run_id, auth, params)
             else:
                 raise HTTPException(status_code=400, detail="Runner invoke URL not set for local runner")
         elif runner == "local_runner":
@@ -653,7 +653,7 @@ def run_agent(
                 f"assistant_id={run_model.assistant_id}, "
                 f"thread_id={thread_id}, run_id={run_id}"
             )
-            invoke_agent_via_lambda(function_name, agents, thread_id, run_id, auth, "", params)
+            invoke_agent_via_lambda(function_name, agents, thread_id, run_id, auth, params)
         # with get_session() as session:
         if run_model.parent_run_id:
             parent_run = session.get(RunModel, run_model.parent_run_id)

--- a/nearai/aws_runner/service.py
+++ b/nearai/aws_runner/service.py
@@ -52,7 +52,6 @@ def handler(event, context):
         stop_time_val = time.perf_counter()
         write_metric("VerifySignatureDuration", stop_time_val - start_time_val)
 
-    new_message = event.get("new_message")
     thread_id = event.get("thread_id")
     run_id = event.get("run_id")
 
@@ -63,7 +62,6 @@ def handler(event, context):
         auth_object,
         thread_id,
         run_id,
-        new_message=new_message,
         params=params,
     )
     if not new_thread_id:

--- a/nearai/cli.py
+++ b/nearai/cli.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from textwrap import fill
 from typing import Any, Dict, List, Optional, Union
 
-import boto3
 import fire
 from openai.types.beta.threads.message import Attachment
 from tabulate import tabulate
@@ -613,44 +612,6 @@ class AgentCli:
         self.last_thread_id = thread.id
 
         return last_message_id
-
-    def run_remote(
-        self,
-        agent: str,
-        new_message: str = "",
-        environment_id: str = "",
-        provider: str = "aws_lambda",
-        params: object = None,
-        framework: str = "base",
-        environment: str = "production",
-    ) -> None:
-        """Invoke a Container based AWS lambda function to run an agent on a given environment."""
-        from nearai.clients.lambda_client import LambdaWrapper
-
-        if not CONFIG.auth:
-            print("Please login with `nearai login`")
-            return
-        if provider != "aws_lambda":
-            print(f"Provider {provider} is not supported.")
-            return
-        if not params:
-            params = {"max_iterations": 1}
-
-        wrapper = LambdaWrapper(boto3.client("lambda", region_name="us-east-2"))
-        try:
-            new_environment = wrapper.invoke_function(
-                f"{environment}-agent-runner-{framework}",
-                {
-                    "agents": agent,
-                    "environment_id": environment_id,
-                    "auth": CONFIG.auth.model_dump(),
-                    "new_message": new_message,
-                    "params": params,
-                },
-            )
-            print(f"Agent run finished. New environment is {new_environment}")
-        except Exception as e:
-            print(f"Error running agent remotely: {e}")
 
     def create(self, name: Optional[str] = None, description: Optional[str] = None, fork: Optional[str] = None) -> None:
         """Create a new agent or fork an existing one.


### PR DESCRIPTION
 * the `new_message` param is only used by benchmarking, removed other references since they have been replaced by adding the message to the thread.
 * Also removed `run_remote` cli method used for lambda runner testing before the api had full support for it.