### PR TITLE
Fix reload agent logic after saving agent secrets

### DIFF
--- a/hub/demo/src/components/AgentRunner.tsx
+++ b/hub/demo/src/components/AgentRunner.tsx
@@ -214,7 +214,6 @@ export const AgentRunner = ({
     agentRequestsNeedingPermissions,
     setAgentRequestsNeedingPermissions,
     conditionallyProcessAgentRequests,
-    iframeNonce,
     iframePostMessage,
     onIframePostMessage,
   } = useAgentRequestsWithIframe(currentEntry, chatMutation, threadId);
@@ -373,7 +372,6 @@ export const AgentRunner = ({
                 <>
                   <IframeWithBlob
                     html={htmlOutput}
-                    nonce={iframeNonce}
                     onPostMessage={onIframePostMessage}
                     postMessage={iframePostMessage}
                   />

--- a/hub/demo/src/components/AgentRunner.tsx
+++ b/hub/demo/src/components/AgentRunner.tsx
@@ -121,6 +121,7 @@ export const AgentRunner = ({
   const optimisticMessages = useThreadsStore(
     (store) => store.optimisticMessages,
   );
+  const initialUserMessageSent = useRef(false);
   const chatMutationThreadId = useRef('');
   const chatMutationStartedAt = useRef<Date | null>(null);
   const resetThreadsStore = useThreadsStore((store) => store.reset);
@@ -314,6 +315,7 @@ export const AgentRunner = ({
 
   useEffect(() => {
     if (threadId !== chatMutationThreadId.current) {
+      initialUserMessageSent.current = false;
       chatMutationThreadId.current = '';
       chatMutationStartedAt.current = null;
       resetThreadsStore();
@@ -341,7 +343,8 @@ export const AgentRunner = ({
     const initialUserMessage = agentDetails?.initial_user_message;
     const maxIterations = agentDetails?.defaults?.max_iterations ?? 1;
 
-    if (initialUserMessage && !threadId && !chatMutation.isPending) {
+    if (initialUserMessage && !threadId && !initialUserMessageSent.current) {
+      initialUserMessageSent.current = true;
       void chatMutation.mutateAsync({
         max_iterations: maxIterations,
         new_message: initialUserMessage,

--- a/hub/demo/src/components/EntryEnvironmentVariables.tsx
+++ b/hub/demo/src/components/EntryEnvironmentVariables.tsx
@@ -322,7 +322,7 @@ const SecretForm = ({ entry, existingVariable, onFinish }: SecretFormProps) => {
   const addMutation = api.hub.addSecret.useMutation();
   const removeMutation = api.hub.removeSecret.useMutation();
   const utils = api.useUtils();
-  const isAuthenticated = useAuthStore((store) => store.isAuthenticated);
+  const auth = useAuthStore((store) => store.auth);
   const params = useEntryParams();
 
   useEffect(() => {
@@ -382,7 +382,7 @@ const SecretForm = ({ entry, existingVariable, onFinish }: SecretFormProps) => {
   return (
     <Form onSubmit={form.handleSubmit(onSubmit)}>
       <Flex direction="column" gap="l">
-        {isAuthenticated ? (
+        {auth ? (
           <>
             <Flex direction="column" gap="m">
               <Text size="text-s">
@@ -396,6 +396,18 @@ const SecretForm = ({ entry, existingVariable, onFinish }: SecretFormProps) => {
                 query parameter variable with the same key.
               </Text>
             </Flex>
+
+            {auth.account_id === entry.namespace && (
+              <Card background="amber-2" border="amber-4">
+                <Text color="amber-11" size="text-s">
+                  You are the owner of this {entry.category}. Any secrets you
+                  save will be inherited (but NOT visible) when other users run
+                  this {entry.category}. Users of your {entry.category} can add
+                  their own secrets to override these default values for
+                  themselves.
+                </Text>
+              </Card>
+            )}
 
             <Input
               label="Key"

--- a/hub/demo/src/components/lib/IframeWithBlob.tsx
+++ b/hub/demo/src/components/lib/IframeWithBlob.tsx
@@ -14,7 +14,6 @@ export type IframePostMessageEventHandler<T = any> = (
 
 type Props = Omit<ComponentProps<'iframe'>, 'nonce'> & {
   html: string;
-  nonce?: number | null;
   onPostMessage?: IframePostMessageEventHandler;
   postMessage?: unknown;
 };
@@ -22,7 +21,6 @@ type Props = Omit<ComponentProps<'iframe'>, 'nonce'> & {
 export const IframeWithBlob = ({
   className = '',
   html,
-  nonce,
   onPostMessage,
   postMessage,
   ...props
@@ -99,7 +97,7 @@ export const IframeWithBlob = ({
     return () => {
       URL.revokeObjectURL(url);
     };
-  }, [html, nonce]);
+  }, [html]);
 
   useEffect(() => {
     function messageListener(event: MessageEvent) {

--- a/hub/demo/src/lib/models.ts
+++ b/hub/demo/src/lib/models.ts
@@ -284,6 +284,7 @@ export const agentAddSecretsRequestModel = z.object({
     .array(),
   requestId: z.string().nullish(),
   reloadAgentOnSuccess: z.boolean().default(true),
+  reloadAgentMessage: z.string().nullish(),
 });
 
 export const threadMetadataModel = z.intersection(


### PR DESCRIPTION
Closes: https://github.com/nearai/nearai/issues/643

- Add notice text when saving secret for agent that you published
- Update reload agent flow when saving secrets
- Fixes bug related to `initial_user_message` spawning two threads instead of just one

<img width="601" alt="Screenshot 2024-12-18 at 10 10 20 AM" src="https://github.com/user-attachments/assets/1ab4b369-d1e9-4260-9062-705c9b4488a5" />
