### PR TITLE
Set release to use python 3.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: '3.11'
         
     - name: Install poetry
       run: pipx install poetry


### PR DESCRIPTION
The release to PyPi https://github.com/nearai/nearai/actions/workflows/release.yml has been failing https://github.com/nearai/nearai/actions/runs/12439186816/job/34732522578

Since it appears to be using 3.12 and it's only recently that our dependency tree prevented 3.12 from building, it seems like a likely culprit. 