### PR TITLE
replace python command with python3

### DIFF
--- a/docs/agents/quickstart.md
+++ b/docs/agents/quickstart.md
@@ -20,7 +20,7 @@ To get started, you will need to have a [Near account](https://wallet.near.org/)
 === "pip"
 
     ``` bash
-    python -m pip install nearai
+    python3 -m pip install nearai
     ```
 
 === "local"


### PR DESCRIPTION
**Description:**

- Updated all instances of `python` to `python3` in code snippets, commands, and instructions within the documentation.  