### PR TITLE
Order Vector Store Results in Ascending Order

### DIFF
--- a/hub/api/v1/sql.py
+++ b/hub/api/v1/sql.py
@@ -480,7 +480,7 @@ class SqlClient:
         SELECT vse.file_id, vse.chunk_text, vse.embedding <-> %s AS distance
         FROM vector_store_embeddings vse
         WHERE vse.vector_store_id = %s
-        ORDER BY distance desc
+        ORDER BY distance
         LIMIT %s
         """
         query_embedding_json = json.dumps(query_embedding)


### PR DESCRIPTION
When querying the `vector_store` embeddings, we are ordering the results in DESC order (i.e. largest value first, lowest value last), this means that we get the X **more distant results**, which are the results that are the **LEAST similar** to the query

I have removed the `DESC` keyword from the ordering since `ORDER BY` sorts the records in ascending order by default [1]

This PR fixes https://github.com/nearai/nearai/issues/719

[1] https://www.w3schools.com/sql/sql_orderby.asp