### PR TITLE
Support ?initialUserMessage query param and prompt user for permission

### DIFF
--- a/hub/demo/src/components/AgentPermissionsModal.tsx
+++ b/hub/demo/src/components/AgentPermissionsModal.tsx
@@ -37,12 +37,18 @@ import {
 import { useAgentSettingsStore } from '~/stores/agent-settings';
 import { useAuthStore } from '~/stores/auth';
 
+import { type AgentChatMutationInput } from './AgentRunner';
+import { Code } from './lib/Code';
 import { SignInPrompt } from './SignInPrompt';
 
 export type AgentRequestWithPermissions =
   | {
       action: 'add_secrets';
       input: z.infer<typeof agentAddSecretsRequestModel>;
+    }
+  | {
+      action: 'initial_user_message';
+      input: AgentChatMutationInput;
     }
   | {
       action: 'remote_agent_run';
@@ -66,6 +72,7 @@ export function checkAgentPermissions(
 ) {
   const settings = useAgentSettingsStore.getState().getAgentSettings(agent);
   let allowAddSecrets = true;
+  let allowInitialUserMessage = true;
   let allowRemoteRunCallsToOtherAgents = true;
   let allowWalletTransactionRequests = true;
 
@@ -73,6 +80,9 @@ export function checkAgentPermissions(
     if (action === 'add_secrets') {
       // Always prompt a user for permission to add secrets
       allowAddSecrets = false;
+    } else if (action === 'initial_user_message') {
+      // Always prompt a user for permission to run initial user message
+      allowInitialUserMessage = false;
     } else if (action === 'remote_agent_run') {
       allowRemoteRunCallsToOtherAgents =
         idMatchesEntry(input.agent_id, agent) ||
@@ -85,6 +95,7 @@ export function checkAgentPermissions(
 
   const allowed =
     allowAddSecrets &&
+    allowInitialUserMessage &&
     allowRemoteRunCallsToOtherAgents &&
     allowWalletTransactionRequests;
 
@@ -92,6 +103,7 @@ export function checkAgentPermissions(
     allowed,
     permissions: {
       allowAddSecrets,
+      allowInitialUserMessage,
       allowRemoteRunCallsToOtherAgents,
       allowWalletTransactionRequests,
     },
@@ -159,7 +171,14 @@ export const AgentPermissionsModal = ({
   }, []);
 
   const requestsThatCanBeAlwaysAllowed =
-    requests?.filter(({ action }) => action !== 'add_secrets') ?? [];
+    requests?.filter(
+      ({ action }) =>
+        action !== 'add_secrets' && action !== 'initial_user_message',
+    ) ?? [];
+
+  const initialUserMessageRequest = requests?.find(
+    (request) => request.action === 'initial_user_message',
+  );
 
   return (
     <Dialog.Root open={requests !== null} onOpenChange={() => clearRequests()}>
@@ -171,6 +190,25 @@ export const AgentPermissionsModal = ({
                 {!check.permissions.allowAddSecrets && (
                   <SecretsToAdd agent={agent} requests={requests} />
                 )}
+
+                {!check.permissions.allowInitialUserMessage &&
+                  initialUserMessageRequest && (
+                    <>
+                      <Text>
+                        The current agent{' '}
+                        <Text href={`/agents/${agentId}`} target="_blank">
+                          {agentId}
+                        </Text>{' '}
+                        wants to start a new thread with an initial message on
+                        your behalf:
+                      </Text>
+
+                      <Code
+                        language="markdown"
+                        source={initialUserMessageRequest.input.new_message}
+                      />
+                    </>
+                  )}
 
                 {!check.permissions.allowRemoteRunCallsToOtherAgents && (
                   <>

--- a/hub/demo/src/hooks/agent-iframe-requests.ts
+++ b/hub/demo/src/hooks/agent-iframe-requests.ts
@@ -151,7 +151,10 @@ export function useAgentRequestsWithIframe(
           });
 
           void utils.hub.secrets.refetch();
-        } else if (action === 'remote_agent_run') {
+        } else if (
+          action === 'remote_agent_run' ||
+          action === 'initial_user_message'
+        ) {
           await chatMutation.mutateAsync(input);
         } else if (action === 'near_send_transactions') {
           if (wallet) {


### PR DESCRIPTION
Closes: https://github.com/nearai/nearai/issues/707

Example URL: `/agents/flatirons.near/example-travel-agent/latest/run?initialUserMessage=%7B"action"%3A"pay-me"%2C"amount"%3A2.5%7D`

If an `initial_user_message` is defined in the agent's metadata, the UI will now prompt for permission as well. The URL query parameter will always take priority and override any potential value defined in metadata.

<img width="720" alt="Screenshot 2025-01-17 at 10 00 01 AM" src="https://github.com/user-attachments/assets/7b0c327c-f87a-4c8c-bb2e-98736335a371" />