### PR TITLE
Fix sign out cookie delete logic

### DIFF
--- a/hub/demo/package-lock.json
+++ b/hub/demo/package-lock.json
@@ -2755,6 +2755,126 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.21.tgz",
+      "integrity": "sha512-TSAA2ROgNzm4FhKbTbyJOBrsREOMVdDIltZ6aZiKvCi/v0UwFmwigBGeqXDA97TFMpR3LNNpw52CbVelkoQBxA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.21.tgz",
+      "integrity": "sha512-0Dqjn0pEUz3JG+AImpnMMW/m8hRtl1GQCNbO66V1yp6RswSTiKmnHf3pTX6xMdJYSemf3O4Q9ykiL0jymu0TuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.21.tgz",
+      "integrity": "sha512-Ggfw5qnMXldscVntwnjfaQs5GbBbjioV4B4loP+bjqNEb42fzZlAaK+ldL0jm2CTJga9LynBMhekNfV8W4+HBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.21.tgz",
+      "integrity": "sha512-uokj0lubN1WoSa5KKdThVPRffGyiWlm/vCc/cMkWOQHw69Qt0X1o3b2PyLLx8ANqlefILZh1EdfLRz9gVpG6tg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.21.tgz",
+      "integrity": "sha512-iAEBPzWNbciah4+0yI4s7Pce6BIoxTQ0AGCkxn/UBuzJFkYyJt71MadYQkjPqCQCJAFQ26sYh7MOKdU+VQFgPg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.21.tgz",
+      "integrity": "sha512-plykgB3vL2hB4Z32W3ktsfqyuyGAPxqwiyrAi2Mr8LlEUhNn9VgkiAl5hODSBpzIfWweX3er1f5uNpGDygfQVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.21.tgz",
+      "integrity": "sha512-w5bacz4Vxqrh06BjWgua3Yf7EMDb8iMcVhNrNx8KnJXt8t+Uu0Zg4JHLDL/T7DkTCEEfKXO/Er1fcfWxn2xfPA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.21",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.21.tgz",
+      "integrity": "sha512-sT6+llIkzpsexGYZq8cjjthRyRGe5cJVhqh12FmlbxHqna6zsDDK8UNaV7g41T6atFHCJUPeLb3uyAwrBwy0NA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",

--- a/hub/demo/src/components/Navigation.tsx
+++ b/hub/demo/src/components/Navigation.tsx
@@ -36,6 +36,7 @@ import { signInWithNear } from '~/lib/auth';
 import { ENTRY_CATEGORY_LABELS } from '~/lib/entries';
 import { useAuthStore } from '~/stores/auth';
 import { useWalletStore } from '~/stores/wallet';
+import { trpc } from '~/trpc/TRPCProvider';
 
 import s from './Navigation.module.scss';
 import { NewAgentButton } from './NewAgentButton';
@@ -101,6 +102,7 @@ const resourcesNavItems = env.NEXT_PUBLIC_CONSUMER_MODE
 export const Navigation = () => {
   const auth = useAuthStore((store) => store.auth);
   const clearAuth = useAuthStore((store) => store.clearAuth);
+  const clearTokenMutation = trpc.auth.clearToken.useMutation();
   const isAuthenticated = useAuthStore((store) => store.isAuthenticated);
   const wallet = useWalletStore((store) => store.wallet);
   const path = usePathname();
@@ -115,7 +117,7 @@ export const Navigation = () => {
     if (wallet) {
       void wallet.signOut();
     }
-
+    void clearTokenMutation.mutate();
     clearAuth();
   };
 

--- a/hub/demo/src/components/ZustandHydration.tsx
+++ b/hub/demo/src/components/ZustandHydration.tsx
@@ -18,17 +18,8 @@ function migrateLocalStorageStoreNames() {
     This function migrates our legacy Zustand local storage keys 
     to our new storage key standard before hydrating:
 
-    "store" => "AuthStore"
     "agent-settings" => "AgentSettingsStore"
   */
-
-  if (!localStorage.getItem('AuthStore')) {
-    const store = localStorage.getItem('store');
-    if (store) {
-      localStorage.setItem('AuthStore', store);
-      localStorage.removeItem('store');
-    }
-  }
 
   if (!localStorage.getItem('AgentSettingsStore')) {
     const store = localStorage.getItem('agent-settings');
@@ -49,6 +40,8 @@ function returnLocalStorageAuthStoreToMigrate() {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         JSON.parse(raw)?.state?.auth,
       );
+
+      localStorage.removeItem(authStoreName);
     } catch (error) {}
   }
 

--- a/hub/demo/src/trpc/routers/auth.ts
+++ b/hub/demo/src/trpc/routers/auth.ts
@@ -5,7 +5,7 @@ import { createTRPCRouter, publicProcedure } from '../trpc';
 
 export const AUTH_COOKIE_NAME = 'auth';
 const AUTH_COOKIE_MAX_AGE_SECONDS = 31536000 * 100; // 100 years
-export const AUTH_COOKIE_DELETE = `${AUTH_COOKIE_NAME}=null; Max-Age=-1`;
+export const AUTH_COOKIE_DELETE = `${AUTH_COOKIE_NAME}=null; Expires=Thu, 01 Jan 1970 00:00:00 GMT`;
 
 export const authRouter = createTRPCRouter({
   saveToken: publicProcedure


### PR DESCRIPTION
I found an issue with our new cookie logic when signing out. The auth cookie wasn't properly being deleted. This fixes that. Also realized there was some Zustand hydration logic that could be cleaned up since we're no longer using local storage to store your auth session. The `package-lock.json` file wanted to update - so that's most of the diff.