### PR TITLE
Cookie sign out fix #2

### DIFF
--- a/hub/demo/src/trpc/routers/auth.ts
+++ b/hub/demo/src/trpc/routers/auth.ts
@@ -3,24 +3,25 @@ import { authorizationModel } from '~/lib/models';
 
 import { createTRPCRouter, publicProcedure } from '../trpc';
 
+/*
+  In production for app.near.ai and chat.near.ai, the value for AUTH_COOKIE_DOMAIN 
+  will be "near.ai" - which will make the cookie accessible for near.ai and *.near.ai domains: 
+  https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
+*/
+
 export const AUTH_COOKIE_NAME = 'auth';
 const AUTH_COOKIE_MAX_AGE_SECONDS = 31536000 * 100; // 100 years
-export const AUTH_COOKIE_DELETE = `${AUTH_COOKIE_NAME}=null; Expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+const AUTH_COOKIE_STANDARD_FLAGS = `SameSite=Strict; Path=/; HttpOnly; Secure`;
+const AUTH_COOKIE_FLAGS = env.AUTH_COOKIE_DOMAIN
+  ? `${AUTH_COOKIE_STANDARD_FLAGS}; Domain=${env.AUTH_COOKIE_DOMAIN}`
+  : AUTH_COOKIE_STANDARD_FLAGS;
+export const AUTH_COOKIE_DELETE = `${AUTH_COOKIE_NAME}=null; Expires=Thu, 01 Jan 1970 00:00:00 GMT; ${AUTH_COOKIE_FLAGS}`;
 
 export const authRouter = createTRPCRouter({
   saveToken: publicProcedure
     .input(authorizationModel)
     .mutation(({ ctx, input }) => {
-      let authCookie = `${AUTH_COOKIE_NAME}=${encodeURIComponent(JSON.stringify(input))}; Max-Age=${AUTH_COOKIE_MAX_AGE_SECONDS}; HttpOnly; Secure`;
-
-      if (env.AUTH_COOKIE_DOMAIN) {
-        /*
-          In production for app.near.ai and chat.near.ai, the value for AUTH_COOKIE_DOMAIN 
-          will be "near.ai" - which will make the cookie accessible for near.ai and *.near.ai domains: 
-          https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
-        */
-        authCookie += `; Domain=${env.AUTH_COOKIE_DOMAIN}`;
-      }
+      let authCookie = `${AUTH_COOKIE_NAME}=${encodeURIComponent(JSON.stringify(input))}; Max-Age=${AUTH_COOKIE_MAX_AGE_SECONDS}; ${AUTH_COOKIE_FLAGS}`;
 
       ctx.resHeaders.set('Set-Cookie', authCookie);
 

--- a/hub/demo/src/trpc/routers/auth.ts
+++ b/hub/demo/src/trpc/routers/auth.ts
@@ -21,7 +21,7 @@ export const authRouter = createTRPCRouter({
   saveToken: publicProcedure
     .input(authorizationModel)
     .mutation(({ ctx, input }) => {
-      let authCookie = `${AUTH_COOKIE_NAME}=${encodeURIComponent(JSON.stringify(input))}; Max-Age=${AUTH_COOKIE_MAX_AGE_SECONDS}; ${AUTH_COOKIE_FLAGS}`;
+      const authCookie = `${AUTH_COOKIE_NAME}=${encodeURIComponent(JSON.stringify(input))}; Max-Age=${AUTH_COOKIE_MAX_AGE_SECONDS}; ${AUTH_COOKIE_FLAGS}`;
 
       ctx.resHeaders.set('Set-Cookie', authCookie);
 

--- a/hub/demo/src/trpc/routers/auth.ts
+++ b/hub/demo/src/trpc/routers/auth.ts
@@ -15,7 +15,7 @@ const AUTH_COOKIE_STANDARD_FLAGS = `SameSite=Strict; Path=/; HttpOnly; Secure`;
 const AUTH_COOKIE_FLAGS = env.AUTH_COOKIE_DOMAIN
   ? `${AUTH_COOKIE_STANDARD_FLAGS}; Domain=${env.AUTH_COOKIE_DOMAIN}`
   : AUTH_COOKIE_STANDARD_FLAGS;
-export const AUTH_COOKIE_DELETE = `${AUTH_COOKIE_NAME}=null; Expires=Thu, 01 Jan 1970 00:00:00 GMT; ${AUTH_COOKIE_FLAGS}`;
+export const AUTH_COOKIE_DELETE = `${AUTH_COOKIE_NAME}=null; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age: 0; ${AUTH_COOKIE_FLAGS}`;
 
 export const authRouter = createTRPCRouter({
   saveToken: publicProcedure


### PR DESCRIPTION
Adjusting cookie syntax to hopefully fix production issue where auth cookie is never deleted. For some reason the issue only occurs in production so it has been tough to nail down.