### PR TITLE
Cache all agent files

### DIFF
--- a/nearai/agents/agent.py
+++ b/nearai/agents/agent.py
@@ -21,6 +21,7 @@ class Agent(object):
         self, identifier: str, agent_files: Union[List, Path], metadata: Dict, change_to_temp_dir: bool = True
     ):  # noqa: D107
         self.code: Optional[CodeType] = None
+        self.file_cache: dict[str, str] = {}
         self.identifier = identifier
         name_parts = identifier.split("/")
         self.namespace = name_parts[0]
@@ -134,6 +135,14 @@ class Agent(object):
                 raise ValueError(f"Agent run error: {AGENT_FILENAME} does not exist")
             with open(self.agent_filename, "r") as f:
                 self.code = compile(f.read(), self.agent_filename, "exec")
+
+            # cache all agent files in file_cache
+            for root, _, files in os.walk(self.temp_dir):
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    with open(file_path, "r") as f:
+                        self.file_cache[file] = f.read()
+
         else:
             print("Using cached agent code")
 

--- a/nearai/agents/agent.py
+++ b/nearai/agents/agent.py
@@ -21,7 +21,7 @@ class Agent(object):
         self, identifier: str, agent_files: Union[List, Path], metadata: Dict, change_to_temp_dir: bool = True
     ):  # noqa: D107
         self.code: Optional[CodeType] = None
-        self.file_cache: dict[str, str] = {}
+        self.file_cache: dict[str, Union[str, bytes]] = {}
         self.identifier = identifier
         name_parts = identifier.split("/")
         self.namespace = name_parts[0]
@@ -133,15 +133,26 @@ class Agent(object):
             self.agent_filename = os.path.join(self.temp_dir, AGENT_FILENAME)
             if not os.path.exists(self.agent_filename):
                 raise ValueError(f"Agent run error: {AGENT_FILENAME} does not exist")
-            with open(self.agent_filename, "r") as f:
-                self.code = compile(f.read(), self.agent_filename, "exec")
+            with open(self.agent_filename, "r") as agent_file:
+                self.code = compile(agent_file.read(), self.agent_filename, "exec")
 
             # cache all agent files in file_cache
             for root, _, files in os.walk(self.temp_dir):
                 for file in files:
                     file_path = os.path.join(root, file)
-                    with open(file_path, "r") as f:
-                        self.file_cache[file] = f.read()
+                    relative_path = os.path.relpath(file_path, self.temp_dir)
+                    try:
+                        with open(file_path, "rb") as f:
+                            content = f.read()
+                            try:
+                                # Try to decode as text
+                                self.file_cache[relative_path] = content.decode("utf-8")
+                            except UnicodeDecodeError:
+                                # If decoding fails, store as binary
+                                self.file_cache[relative_path] = content
+
+                    except Exception as e:
+                        print(f"Error with cache creation {file_path}: {e}")
 
         else:
             print("Using cached agent code")

--- a/nearai/agents/environment.py
+++ b/nearai/agents/environment.py
@@ -748,6 +748,7 @@ class Environment(object):
                     file_content = file_cache.get(filename, None)
 
             # Write the file content from the thread or cache to the local filesystem
+            # This allows exec_command to operate on the file
             if file_content:
                 if not os.path.exists(os.path.dirname(local_path)):
                     os.makedirs(os.path.dirname(local_path))

--- a/nearai/openapi_client/api_client.py
+++ b/nearai/openapi_client/api_client.py
@@ -313,8 +313,13 @@ class ApiClient:
                 if content_type is not None:
                     match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
                 encoding = match.group(1) if match else "utf-8"
-                response_text = response_data.data.decode(encoding)
-                return_data = self.deserialize(response_text, response_type, content_type)
+
+                try:
+                    response_text = response_data.data.decode(encoding)
+                    return_data = self.deserialize(response_text, response_type, content_type)
+                except UnicodeDecodeError:
+                    # binary response
+                    return_data = response_data.data
         finally:
             if not 200 <= response_data.status <= 299:
                 raise ApiException.from_response(

--- a/nearai/projects/streamer/agent.py
+++ b/nearai/projects/streamer/agent.py
@@ -75,7 +75,7 @@ class StreamerAgent(object):
                     command_outcome = "Done"
                 elif command.startswith("read"):
                     filename = command.split("read ")[1]
-                    content = env.read_file(filename)
+                    content = str(env.read_file(filename) or "")
                     command_outcome = f"Read file {filename} with content: {content}"
                 elif command.startswith("list"):
                     path = command.split("list ")[1].strip()


### PR DESCRIPTION
Agent files may include supporting files such as data or templates that the agent loads during processing. This change caches those files along with the code so they can be accessed during runs when files are not fetched because the agent is cached. 
Agent code in agent.py was cached in a previous PR. Python files other than agent.py are cached by the python runtime when they are pulled in by a import statements in agent.py.

Note: this code has been deployed to production Lambda runners already. Production testing passed with `botfather` agent.