### PR TITLE
Improve entries table performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ site/
 .cache/
 .venv/
 last_block_id.txt
+.DS_Store

--- a/hub/demo/src/components/EntriesTable.tsx
+++ b/hub/demo/src/components/EntriesTable.tsx
@@ -12,12 +12,19 @@ import {
   Tooltip,
   useTable,
 } from '@near-pagoda/ui';
-import { ChatCircleDots, CodeBlock, Play } from '@phosphor-icons/react';
+import {
+  ArrowLeft,
+  ArrowRight,
+  ChatCircleDots,
+  CodeBlock,
+  Play,
+} from '@phosphor-icons/react';
 import { format, formatDistanceToNow } from 'date-fns';
-import { type ReactNode } from 'react';
+import { type ReactNode, useEffect } from 'react';
 
 import { env } from '~/env';
 import { useEntriesSearch } from '~/hooks/entries';
+import { useClientPagination } from '~/hooks/pagination';
 import {
   benchmarkEvaluationsUrlForEntry,
   ENTRY_CATEGORY_LABELS,
@@ -61,6 +68,24 @@ export const EntriesTable = ({
     sortOrder: 'DESCENDING',
   });
 
+  const {
+    createPageQueryPath,
+    page,
+    previousPage,
+    nextPage,
+    pageItems,
+    totalPagesTruncatedAsArray,
+  } = useClientPagination({
+    data: sorted,
+    itemsPerPage: 30,
+  });
+
+  // TODO: Reset page on search or column sort change
+  // useEffect(() => {
+  //   setPage(undefined);
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, [tableProps.sort, searchQuery]);
+
   return (
     <Section bleed={bleed} padding={bleed ? 'none' : undefined}>
       <Grid
@@ -88,7 +113,6 @@ export const EntriesTable = ({
           type="search"
           name="search"
           placeholder={`Search ${title}`}
-          value={searchQuery}
           onInput={(event) => setSearchQuery(event.currentTarget.value)}
         />
       </Grid>
@@ -144,7 +168,7 @@ export const EntriesTable = ({
           <Table.Body>
             {!sorted && <Table.PlaceholderRows />}
 
-            {sorted?.map((entry, index) => (
+            {pageItems?.map((entry, index) => (
               <Table.Row key={index}>
                 <Table.Cell
                   href={primaryUrlForEntry(entry)}
@@ -260,6 +284,54 @@ export const EntriesTable = ({
               </Table.Row>
             ))}
           </Table.Body>
+
+          {totalPagesTruncatedAsArray.length > 1 && (
+            <Table.Foot sticky={false}>
+              <Table.Row>
+                <Table.Cell colSpan={100}>
+                  <Flex align="center" justify="space-between" gap="m">
+                    <Button
+                      label="Previous Page"
+                      icon={<ArrowLeft />}
+                      href={
+                        previousPage
+                          ? createPageQueryPath({
+                              page: previousPage.toString(),
+                            })
+                          : undefined
+                      }
+                      disabled={!previousPage}
+                    />
+
+                    <Flex align="center" justify="center" gap="m" wrap="wrap">
+                      {totalPagesTruncatedAsArray.map((p) => (
+                        <Text
+                          color={p === page ? 'sand-12' : undefined}
+                          decoration={p === page ? 'underline' : 'none'}
+                          href={createPageQueryPath({ page: p.toString() })}
+                          size="text-s"
+                          key={p}
+                        >
+                          {p}
+                        </Text>
+                      ))}
+                    </Flex>
+
+                    <Button
+                      label="Next Page"
+                      icon={<ArrowRight />}
+                      href={
+                        nextPage
+                          ? createPageQueryPath({ page: nextPage.toString() })
+                          : undefined
+                      }
+                      disabled={!nextPage}
+                    />
+                  </Flex>
+                </Table.Cell>
+              </Table.Row>
+            </Table.Foot>
+          )}
         </Table.Root>
       )}
     </Section>

--- a/hub/demo/src/components/EntriesTable.tsx
+++ b/hub/demo/src/components/EntriesTable.tsx
@@ -12,15 +12,9 @@ import {
   Tooltip,
   useTable,
 } from '@near-pagoda/ui';
-import {
-  ArrowLeft,
-  ArrowRight,
-  ChatCircleDots,
-  CodeBlock,
-  Play,
-} from '@phosphor-icons/react';
+import { ChatCircleDots, CodeBlock, Play } from '@phosphor-icons/react';
 import { format, formatDistanceToNow } from 'date-fns';
-import { type ReactNode, useEffect } from 'react';
+import { type ReactNode } from 'react';
 
 import { env } from '~/env';
 import { useEntriesSearch } from '~/hooks/entries';
@@ -36,6 +30,7 @@ import { trpc } from '~/trpc/TRPCProvider';
 
 import { ForkButton } from './ForkButton';
 import { NewAgentButton } from './NewAgentButton';
+import { Pagination } from './Pagination';
 import { StarButton } from './StarButton';
 
 type Props = {
@@ -68,23 +63,11 @@ export const EntriesTable = ({
     sortOrder: 'DESCENDING',
   });
 
-  const {
-    createPageQueryPath,
-    page,
-    previousPage,
-    nextPage,
-    pageItems,
-    totalPagesTruncatedAsArray,
-  } = useClientPagination({
-    data: sorted,
-    itemsPerPage: 30,
-  });
-
-  // TODO: Reset page on search or column sort change
-  // useEffect(() => {
-  //   setPage(undefined);
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, [tableProps.sort, searchQuery]);
+  const { pageItems, totalPages, setPage, ...paginationProps } =
+    useClientPagination({
+      data: sorted,
+      itemsPerPage: 30,
+    });
 
   return (
     <Section bleed={bleed} padding={bleed ? 'none' : undefined}>
@@ -113,7 +96,10 @@ export const EntriesTable = ({
           type="search"
           name="search"
           placeholder={`Search ${title}`}
-          onInput={(event) => setSearchQuery(event.currentTarget.value)}
+          onInput={(event) => {
+            setPage(undefined);
+            setSearchQuery(event.currentTarget.value);
+          }}
         />
       </Grid>
 
@@ -131,6 +117,7 @@ export const EntriesTable = ({
           {...tableProps}
           setSort={(value) => {
             void entriesQuery.refetch();
+            setPage(undefined);
             tableProps.setSort(value);
           }}
         >
@@ -285,49 +272,11 @@ export const EntriesTable = ({
             ))}
           </Table.Body>
 
-          {totalPagesTruncatedAsArray.length > 1 && (
+          {totalPages > 1 && (
             <Table.Foot sticky={false}>
               <Table.Row>
                 <Table.Cell colSpan={100}>
-                  <Flex align="center" justify="space-between" gap="m">
-                    <Button
-                      label="Previous Page"
-                      icon={<ArrowLeft />}
-                      href={
-                        previousPage
-                          ? createPageQueryPath({
-                              page: previousPage.toString(),
-                            })
-                          : undefined
-                      }
-                      disabled={!previousPage}
-                    />
-
-                    <Flex align="center" justify="center" gap="m" wrap="wrap">
-                      {totalPagesTruncatedAsArray.map((p) => (
-                        <Text
-                          color={p === page ? 'sand-12' : undefined}
-                          decoration={p === page ? 'underline' : 'none'}
-                          href={createPageQueryPath({ page: p.toString() })}
-                          size="text-s"
-                          key={p}
-                        >
-                          {p}
-                        </Text>
-                      ))}
-                    </Flex>
-
-                    <Button
-                      label="Next Page"
-                      icon={<ArrowRight />}
-                      href={
-                        nextPage
-                          ? createPageQueryPath({ page: nextPage.toString() })
-                          : undefined
-                      }
-                      disabled={!nextPage}
-                    />
-                  </Flex>
+                  <Pagination {...paginationProps} />
                 </Table.Cell>
               </Table.Row>
             </Table.Foot>

--- a/hub/demo/src/components/EntriesTable.tsx
+++ b/hub/demo/src/components/EntriesTable.tsx
@@ -155,8 +155,8 @@ export const EntriesTable = ({
           <Table.Body>
             {!sorted && <Table.PlaceholderRows />}
 
-            {pageItems?.map((entry, index) => (
-              <Table.Row key={index}>
+            {pageItems?.map((entry) => (
+              <Table.Row key={entry.id}>
                 <Table.Cell
                   href={primaryUrlForEntry(entry)}
                   style={{ minWidth: '10rem', maxWidth: '20rem' }}

--- a/hub/demo/src/components/EntrySelector.tsx
+++ b/hub/demo/src/components/EntrySelector.tsx
@@ -41,9 +41,7 @@ export const EntrySelector = ({
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const entriesQuery = trpc.hub.entries.useQuery({ category });
 
-  const { searched, searchQuery, setSearchQuery } = useEntriesSearch(
-    entriesQuery.data,
-  );
+  const { searched, setSearchQuery } = useEntriesSearch(entriesQuery.data);
 
   searched?.sort((a, b) => {
     let sort = b.num_stars - a.num_stars;
@@ -65,7 +63,6 @@ export const EntrySelector = ({
         type="search"
         name="search"
         placeholder="Search"
-        value={searchQuery}
         onInput={(event) => setSearchQuery(event.currentTarget.value)}
         ref={searchInputRef}
       />

--- a/hub/demo/src/components/Pagination.tsx
+++ b/hub/demo/src/components/Pagination.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { Button, Flex, Text } from '@near-pagoda/ui';
+import { ArrowLeft, ArrowRight } from '@phosphor-icons/react';
+
+import { type ClientPagination } from '~/hooks/pagination';
+
+type Props = Pick<
+  ClientPagination,
+  | 'previousPage'
+  | 'nextPage'
+  | 'firstPage'
+  | 'lastPage'
+  | 'createPageQueryPath'
+  | 'totalPagesTruncatedAsArray'
+  | 'page'
+>;
+
+export const Pagination = ({
+  previousPage,
+  nextPage,
+  firstPage,
+  lastPage,
+  createPageQueryPath,
+  totalPagesTruncatedAsArray,
+  page,
+}: Props) => {
+  return (
+    <Flex align="center" justify="space-between" gap="m">
+      <Button
+        label="Previous Page"
+        icon={<ArrowLeft />}
+        href={
+          previousPage
+            ? createPageQueryPath({
+                page: previousPage.toString(),
+              })
+            : undefined
+        }
+        disabled={!previousPage}
+      />
+
+      <Flex align="center" justify="center" gap="m" wrap="wrap">
+        {firstPage && !totalPagesTruncatedAsArray.includes(firstPage) && (
+          <>
+            <Text
+              decoration="none"
+              href={createPageQueryPath({
+                page: firstPage.toString(),
+              })}
+              size="text-s"
+            >
+              {firstPage}
+            </Text>
+            <Text size="text-xs">...</Text>
+          </>
+        )}
+
+        {totalPagesTruncatedAsArray.map((p) => (
+          <Text
+            color={p === page ? 'sand-12' : undefined}
+            decoration={p === page ? 'underline' : 'none'}
+            href={createPageQueryPath({ page: p.toString() })}
+            size="text-s"
+            key={p}
+          >
+            {p}
+          </Text>
+        ))}
+
+        {lastPage && !totalPagesTruncatedAsArray.includes(lastPage) && (
+          <>
+            <Text size="text-xs">...</Text>
+            <Text
+              decoration="none"
+              href={createPageQueryPath({
+                page: lastPage.toString(),
+              })}
+              size="text-s"
+            >
+              {lastPage}
+            </Text>
+          </>
+        )}
+      </Flex>
+
+      <Button
+        label="Next Page"
+        icon={<ArrowRight />}
+        href={
+          nextPage
+            ? createPageQueryPath({ page: nextPage.toString() })
+            : undefined
+        }
+        disabled={!nextPage}
+      />
+    </Flex>
+  );
+};

--- a/hub/demo/src/components/ThreadsSidebar.tsx
+++ b/hub/demo/src/components/ThreadsSidebar.tsx
@@ -63,7 +63,7 @@ export const ThreadsSidebar = ({
   const [showAllThreads, setShowAllThreads] = useState(false);
   const threadsToDisplay = showAllThreads
     ? filteredThreads
-    : filteredThreads?.slice(0, 30);
+    : filteredThreads?.slice(0, 50);
   const hiddenThreadsCount =
     (filteredThreads?.length ?? 0) - (threadsToDisplay?.length ?? 0);
 

--- a/hub/demo/src/components/ThreadsSidebar.tsx
+++ b/hub/demo/src/components/ThreadsSidebar.tsx
@@ -60,6 +60,13 @@ export const ThreadsSidebar = ({
   );
   const removeMutation = trpc.hub.removeThread.useMutation();
 
+  const [showAllThreads, setShowAllThreads] = useState(false);
+  const threadsToDisplay = showAllThreads
+    ? filteredThreads
+    : filteredThreads?.slice(0, 30);
+  const hiddenThreadsCount =
+    (filteredThreads?.length ?? 0) - (threadsToDisplay?.length ?? 0);
+
   const currentThreadIdMatchesThread =
     !threadId || !!filteredThreads?.find((thread) => thread.id === threadId);
 
@@ -107,37 +114,38 @@ export const ThreadsSidebar = ({
         </Tooltip>
       </Flex>
 
-      {filteredThreads?.length ? (
-        <Sidebar.SidebarContentBleed>
-          <CardList>
-            {filteredThreads.map((thread) => (
-              <Card
-                href={thread.url}
-                padding="s"
-                paddingInline="m"
-                background={
-                  (currentThreadIdMatchesThread && threadId === thread.id) ||
-                  (!currentThreadIdMatchesThread &&
-                    previousThreadId === thread.id)
-                    ? 'sand-0'
-                    : 'sand-2'
-                }
-                key={thread.id}
-              >
-                <Flex direction="column">
-                  <Flex align="center" gap="s">
-                    <Text
-                      as="span"
-                      size="text-s"
-                      weight={500}
-                      color="sand-12"
-                      clampLines={1}
-                      style={{ marginRight: 'auto' }}
-                    >
-                      {thread.metadata.topic}
-                    </Text>
+      {filteredThreads?.length && threadsToDisplay?.length ? (
+        <>
+          <Sidebar.SidebarContentBleed>
+            <CardList>
+              {threadsToDisplay.map((thread) => (
+                <Card
+                  href={thread.url}
+                  padding="s"
+                  paddingInline="m"
+                  background={
+                    (currentThreadIdMatchesThread && threadId === thread.id) ||
+                    (!currentThreadIdMatchesThread &&
+                      previousThreadId === thread.id)
+                      ? 'sand-0'
+                      : 'sand-2'
+                  }
+                  key={thread.id}
+                >
+                  <Flex direction="column">
+                    <Flex align="center" gap="s">
+                      <Text
+                        as="span"
+                        size="text-s"
+                        weight={500}
+                        color="sand-12"
+                        clampLines={1}
+                        style={{ marginRight: 'auto' }}
+                      >
+                        {thread.metadata.topic}
+                      </Text>
 
-                    {/* <Tooltip
+                      {/* <Tooltip
                     asChild
                     content={`${thread.messageCount} message${thread.messageCount === 1 ? '' : 's'} sent`}
                     key={thread.id}
@@ -148,109 +156,111 @@ export const ThreadsSidebar = ({
                       variant="neutral"
                     />
                   </Tooltip> */}
-                  </Flex>
+                    </Flex>
 
-                  <Flex align="center" gap="s">
-                    <Text
-                      size="text-2xs"
-                      clampLines={1}
-                      style={{ marginRight: 'auto' }}
-                    >
-                      {thread.agent.namespace}/{thread.agent.name}
-                    </Text>
-
-                    {thread.agent.version !== 'latest' && (
-                      <Tooltip
-                        content={`This thread is fixed to a specific agent version: ${thread.agent.version}`}
+                    <Flex align="center" gap="s">
+                      <Text
+                        size="text-2xs"
+                        clampLines={1}
+                        style={{ marginRight: 'auto' }}
                       >
-                        <Badge
-                          size="small"
-                          iconLeft={<Tag />}
-                          label={thread.agent.version}
-                          style={{
-                            maxWidth: '4.5rem',
-                          }}
-                          variant="warning"
-                        />
-                      </Tooltip>
-                    )}
+                        {thread.agent.namespace}/{thread.agent.name}
+                      </Text>
 
-                    <Dropdown.Root>
-                      <Dropdown.Trigger asChild>
-                        <Button
-                          label="Manage Thread"
-                          icon={<DotsThree weight="bold" />}
-                          size="x-small"
-                          fill="ghost"
-                        />
-                      </Dropdown.Trigger>
+                      {thread.agent.version !== 'latest' && (
+                        <Tooltip
+                          content={`This thread is fixed to a specific agent version: ${thread.agent.version}`}
+                        >
+                          <Badge
+                            size="small"
+                            iconLeft={<Tag />}
+                            label={thread.agent.version}
+                            style={{
+                              maxWidth: '4.5rem',
+                            }}
+                            variant="warning"
+                          />
+                        </Tooltip>
+                      )}
 
-                      <Dropdown.Content sideOffset={0}>
-                        <Dropdown.Section>
-                          <Dropdown.SectionContent>
-                            <Text size="text-xs" weight={600} uppercase>
-                              Thread
-                            </Text>
-                          </Dropdown.SectionContent>
-                        </Dropdown.Section>
+                      <Dropdown.Root>
+                        <Dropdown.Trigger asChild>
+                          <Button
+                            label="Manage Thread"
+                            icon={<DotsThree weight="bold" />}
+                            size="x-small"
+                            fill="ghost"
+                          />
+                        </Dropdown.Trigger>
 
-                        <Dropdown.Section>
-                          <Dropdown.Item
-                            onSelect={() => setEditingThreadId(thread.id)}
-                          >
-                            <SvgIcon icon={<Pencil />} />
-                            Rename Thread
-                          </Dropdown.Item>
+                        <Dropdown.Content sideOffset={0}>
+                          <Dropdown.Section>
+                            <Dropdown.SectionContent>
+                              <Text size="text-xs" weight={600} uppercase>
+                                Thread
+                              </Text>
+                            </Dropdown.SectionContent>
+                          </Dropdown.Section>
 
-                          <Dropdown.Item
-                            onSelect={() =>
-                              copyTextToClipboard(
-                                `${window.location.origin}${thread.url}`,
-                              )
-                            }
-                          >
-                            <SvgIcon icon={<LinkIcon />} />
-                            Copy Thread Link
-                          </Dropdown.Item>
+                          <Dropdown.Section>
+                            <Dropdown.Item
+                              onSelect={() => setEditingThreadId(thread.id)}
+                            >
+                              <SvgIcon icon={<Pencil />} />
+                              Rename Thread
+                            </Dropdown.Item>
 
-                          <Dropdown.Item href={thread.agent.url}>
-                            {env.NEXT_PUBLIC_CONSUMER_MODE ? (
-                              <>
-                                <SvgIcon icon={<Plus />} />
-                                New Thread
-                              </>
-                            ) : (
-                              <>
-                                <SvgIcon icon={<Lightbulb />} />
-                                View Agent
-                              </>
-                            )}
-                          </Dropdown.Item>
+                            <Dropdown.Item
+                              onSelect={() =>
+                                copyTextToClipboard(
+                                  `${window.location.origin}${thread.url}`,
+                                )
+                              }
+                            >
+                              <SvgIcon icon={<LinkIcon />} />
+                              Copy Thread Link
+                            </Dropdown.Item>
 
-                          <Dropdown.Item onSelect={() => removeThread(thread)}>
-                            <SvgIcon icon={<Trash />} color="red-10" />
-                            Delete Thread
-                          </Dropdown.Item>
-                        </Dropdown.Section>
+                            <Dropdown.Item href={thread.agent.url}>
+                              {env.NEXT_PUBLIC_CONSUMER_MODE ? (
+                                <>
+                                  <SvgIcon icon={<Plus />} />
+                                  New Thread
+                                </>
+                              ) : (
+                                <>
+                                  <SvgIcon icon={<Lightbulb />} />
+                                  View Agent
+                                </>
+                              )}
+                            </Dropdown.Item>
 
-                        {/* <Dropdown.Section>
-                        <Dropdown.SectionContent>
-                          <Text size="text-xs">
-                            Last message sent at{' '}
-                            <b>
-                              <Timestamp date={thread.lastMessageAt} />
-                            </b>
-                          </Text>
-                        </Dropdown.SectionContent>
-                      </Dropdown.Section> */}
-                      </Dropdown.Content>
-                    </Dropdown.Root>
+                            <Dropdown.Item
+                              onSelect={() => removeThread(thread)}
+                            >
+                              <SvgIcon icon={<Trash />} color="red-10" />
+                              Delete Thread
+                            </Dropdown.Item>
+                          </Dropdown.Section>
+                        </Dropdown.Content>
+                      </Dropdown.Root>
+                    </Flex>
                   </Flex>
-                </Flex>
-              </Card>
-            ))}
-          </CardList>
-        </Sidebar.SidebarContentBleed>
+                </Card>
+              ))}
+            </CardList>
+          </Sidebar.SidebarContentBleed>
+
+          {hiddenThreadsCount > 0 && (
+            <Button
+              size="small"
+              fill="outline"
+              label="Load More Threads"
+              count={hiddenThreadsCount}
+              onClick={() => setShowAllThreads(true)}
+            />
+          )}
+        </>
       ) : (
         <>
           {filteredThreads ? (

--- a/hub/demo/src/hooks/entries.ts
+++ b/hub/demo/src/hooks/entries.ts
@@ -1,6 +1,6 @@
 import { useDebouncedFunction } from '@near-pagoda/ui';
 import { useParams, useSearchParams } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { type z } from 'zod';
 
 import {
@@ -12,8 +12,6 @@ import {
 import { useAuthStore } from '~/stores/auth';
 import { trpc } from '~/trpc/TRPCProvider';
 import { wordsMatchFuzzySearch } from '~/utils/search';
-
-import { useDebouncedValue } from './debounce';
 
 export function useEntryParams(overrides?: {
   namespace?: string;

--- a/hub/demo/src/hooks/entries.ts
+++ b/hub/demo/src/hooks/entries.ts
@@ -1,5 +1,6 @@
+import { useDebouncedFunction } from '@near-pagoda/ui';
 import { useParams, useSearchParams } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { type z } from 'zod';
 
 import {
@@ -77,19 +78,22 @@ export function useCurrentEntry(
 export function useEntriesSearch(
   data: z.infer<typeof entriesModel> | undefined,
 ) {
-  const [searchQuery, setSearchQuery] = useState('');
-  const searchQueryDebounced = useDebouncedValue(searchQuery, 150);
+  const [searchQuery, _setSearchQuery] = useState('');
+
+  const setSearchQuery = useDebouncedFunction((value: string) => {
+    _setSearchQuery(value);
+  }, 150);
 
   const searched = useMemo(() => {
-    if (!data || !searchQueryDebounced) return data;
+    if (!data || !searchQuery) return data;
 
     return data.filter((item) =>
       wordsMatchFuzzySearch(
         [item.namespace, item.name, ...item.tags],
-        searchQueryDebounced,
+        searchQuery,
       ),
     );
-  }, [data, searchQueryDebounced]);
+  }, [data, searchQuery]);
 
   return {
     searched,

--- a/hub/demo/src/hooks/pagination.ts
+++ b/hub/demo/src/hooks/pagination.ts
@@ -20,10 +20,12 @@ export function useClientPagination<
   const totalPages = Math.ceil(totalItems / itemsPerPage);
   const totalPagesAsArray: number[] = [];
 
-  for (let i = 0; i < totalPages * 5; i++) {
+  for (let i = 0; i < totalPages; i++) {
     totalPagesAsArray.push(i + 1);
   }
 
+  const firstPage = totalPagesAsArray[0];
+  const lastPage = totalPagesAsArray.at(-1);
   const currentPageIndex = totalPagesAsArray.indexOf(page);
   const previousPage =
     currentPageIndex > 0 ? totalPagesAsArray[currentPageIndex - 1] : undefined;
@@ -59,11 +61,20 @@ export function useClientPagination<
     return data?.slice(startIndex, endIndex) as T;
   }, [data, itemsPerPage, page]);
 
+  useEffect(() => {
+    if (totalPages > 0 && (page < 1 || page > totalPages)) {
+      setPage(undefined);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [totalPages, page]);
+
   return {
     createPageQueryPath: createQueryPath,
     page,
     previousPage,
     nextPage,
+    firstPage,
+    lastPage,
     pageItems,
     setPage,
     totalItems,
@@ -72,3 +83,5 @@ export function useClientPagination<
     totalPagesTruncatedAsArray,
   };
 }
+
+export type ClientPagination = ReturnType<typeof useClientPagination>;

--- a/hub/demo/src/hooks/pagination.ts
+++ b/hub/demo/src/hooks/pagination.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useQueryParams } from './url';
+
+type UseClientPaginationOptions<
+  T extends Record<string, unknown>[] | undefined,
+> = {
+  data: T;
+  itemsPerPage: number;
+};
+
+export function useClientPagination<
+  T extends Record<string, unknown>[] | undefined,
+>({ data, itemsPerPage }: UseClientPaginationOptions<T>) {
+  const { createQueryPath, updateQueryPath, queryParams } = useQueryParams([
+    'page',
+  ]);
+  const [page, _setPage] = useState(1);
+  const totalItems = data?.length ?? 0;
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+  const totalPagesAsArray: number[] = [];
+
+  for (let i = 0; i < totalPages * 5; i++) {
+    totalPagesAsArray.push(i + 1);
+  }
+
+  const currentPageIndex = totalPagesAsArray.indexOf(page);
+  const previousPage =
+    currentPageIndex > 0 ? totalPagesAsArray[currentPageIndex - 1] : undefined;
+  const nextPage =
+    currentPageIndex < totalPages
+      ? totalPagesAsArray[currentPageIndex + 1]
+      : undefined;
+
+  const pageLimit = 5;
+  const offset = currentPageIndex == 0 ? 0 : currentPageIndex == 1 ? 1 : 2;
+  const offsetIndex = currentPageIndex - offset;
+  const totalPagesTruncatedAsArray = totalPagesAsArray.slice(
+    offsetIndex,
+    offsetIndex + pageLimit,
+  );
+
+  const setPage = useCallback(
+    (value: number | undefined) => {
+      updateQueryPath({
+        page: typeof value === 'number' ? value.toString() : value,
+      });
+    },
+    [updateQueryPath],
+  );
+
+  useEffect(() => {
+    _setPage(() => parseInt(queryParams.page ?? '1') || 1);
+  }, [queryParams.page]);
+
+  const pageItems = useMemo(() => {
+    const startIndex = Math.max(0, (page - 1) * itemsPerPage);
+    const endIndex = startIndex + itemsPerPage;
+    return data?.slice(startIndex, endIndex) as T;
+  }, [data, itemsPerPage, page]);
+
+  return {
+    createPageQueryPath: createQueryPath,
+    page,
+    previousPage,
+    nextPage,
+    pageItems,
+    setPage,
+    totalItems,
+    totalPages,
+    totalPagesAsArray,
+    totalPagesTruncatedAsArray,
+  };
+}

--- a/hub/demo/src/trpc/routers/hub.ts
+++ b/hub/demo/src/trpc/routers/hub.ts
@@ -105,6 +105,9 @@ export const hubRouter = createTRPCRouter({
       const list: z.infer<typeof entriesModel> = data
         .map((item) => {
           const parsed = entryModel.safeParse(item);
+          if (parsed.data?.tags) {
+            parsed.data.tags.sort();
+          }
           return parsed.data;
         })
         .filter((entry) => !!entry);


### PR DESCRIPTION
Closes: https://github.com/nearai/nearai/issues/722

- Added client side pagination to limit the number of table rows rendered in the UI for `<EntriesTable>` and improved search/filter logic to improve perceived performance when searching for an agent.
- Limited the threads shown in the sidebar to 50 until the user clicks `Load More Threads`.

These changes will help the UI perform smoothly as more agents and threads are added over the next few months. Without these changes, the `/agents` page would become unresponsive once we grow to 500+ agents.

<img width="1395" alt="Screenshot 2025-01-22 at 10 15 50 AM" src="https://github.com/user-attachments/assets/9f1583b4-3ed8-42c3-8ad6-d693d7d37e43" />
