### PR TITLE
Prevent pycache files from being included in registry items

### DIFF
--- a/nearai/registry.py
+++ b/nearai/registry.py
@@ -250,6 +250,8 @@ class Registry:
 
         pbar = tqdm(total=total_size, unit="B", unit_scale=True, disable=not show_progress)
         for file, relative, size in all_files:
+            if "__pycache__" in relative.parts:
+                continue
             registry.upload_file(entry_location, file, relative)
             pbar.update(size)
 


### PR DESCRIPTION
We don't want to audit bytecode or have to check that it matches the source.