### PR TITLE
Change commitizen version provider to pep621

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ nearai = "nearai.cli:main"
 name = "cz_conventional_commits"
 tag_format = "v$version"
 version_scheme = "semver2"
-version_provider = "poetry"
+version_provider = "pep621"
 update_changelog_on_bump = true
 major_version_zero = true
 


### PR DESCRIPTION
This should fix PyPI release run:  https://github.com/nearai/nearai/actions/runs/13065999906/job/36458358983