### PR TITLE
Fix 'poetry publish' command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,5 +123,5 @@ jobs:
       if: ${{ github.event.inputs.publish-pypi == 'true' }}
       
     - name: Publish to PyPI
-      run: poetry publish --build
+      run: poetry publish
       if: ${{ github.event.inputs.publish-pypi == 'true' }}


### PR DESCRIPTION
It's supposed to fix this "Publish to PyPI" error: https://github.com/nearai/nearai/actions/runs/13075857012/job/36487730374

I had the same problem with https://github.com/nearai/nearai_langchain and removal of `--build` parameter fixed the problem.