### PR TITLE
Remove cryptography dependency version upper limit

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -9328,4 +9328,4 @@ vllm = ["torch", "vllm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.12"
-content-hash = "6eda4353db1876f60c533cfc11fc155386e0e3449aae851b893cc3fbe085152f"
+content-hash = "a3f1cd3be6ddfa534c08d278a1d582e673a77924bdaff728bf68922ea9d522dc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "base58==2.1.1",
     "boto3>=1.34.100,<2.0.0",
     "boto3-stubs>=1.34.147,<2.0.0",
-    "cryptography>=43.0.0,<44.0.0",
+    "cryptography>=43.0.0",
     "datasets>=2.20.0,<3.0.0",
     "ed25519>=1.5,<2.0",
     "fastapi>=0.111.0,<0.112.0",


### PR DESCRIPTION
There is a cryptography version conflict between `nearai` and `cdp-langchain`:
- nearai wants cryptography (>=43.0.0,<44.0.0)
- cdp-langchain wants cryptography (>=44.0.0,<45.0.0)