### PR TITLE
Update nearai-langchain dependency

### DIFF
--- a/aws_runner/frameworks/requirements-agentkit.txt
+++ b/aws_runner/frameworks/requirements-agentkit.txt
@@ -20,4 +20,4 @@ cdp-agentkit-core >= 0.0.11
 langchain >= 0.3.4
 langchain-openai >= 0.2.4
 langgraph >= 0.2.39
-nearai-langchain >= 0.0.8
+nearai-langchain >= 0.0.9


### PR DESCRIPTION
Version `0.0.8` had serious bug that I have fixed.