### PR TITLE
Add metadata.json to agent files

### DIFF
--- a/nearai/aws_runner/partial_near_client.py
+++ b/nearai/aws_runner/partial_near_client.py
@@ -109,4 +109,7 @@ class PartialNearClient:
         """Fetches an agent from NEAR AI registry."""
         entry_location = self.parse_location(identifier)
         # download all agent files
-        return self.get_files_from_registry(entry_location)
+        files = self.get_files_from_registry(entry_location)
+        # Add metadata as a file
+        files.append({"filename": "metadata.json", "content": self.get_agent_metadata(identifier)})
+        return files


### PR DESCRIPTION
So that `metadata.json` is accessible for agents built on other frameworks.

`nearai_langchain` reads `metadata.json` file.