### PR TITLE
Add langchain_chat_model into environment

### DIFF
--- a/nearai/agents/environment.py
+++ b/nearai/agents/environment.py
@@ -128,6 +128,8 @@ class Environment(object):
         self._run_id = run_id
         self._debug_mode = True if self.env_vars.get("DEBUG") else False
 
+        self.langchain_chat_model = client.create_langchain_chat_model(agents[0].model_provider, agents[0].model)
+
         if fastnear_api_key:
             default_mainnet_rpc = f"https://rpc.mainnet.fastnear.com?apiKey={fastnear_api_key}"
         else:

--- a/nearai/shared/inference_client.py
+++ b/nearai/shared/inference_client.py
@@ -22,6 +22,7 @@ from nearai.shared.client_config import (
     DEFAULT_TIMEOUT,
     ClientConfig,
 )
+from nearai.shared.langchain_chat_model import LangchainChatModel
 from nearai.shared.models import (
     AutoFileChunkingStrategyParam,
     ChunkingStrategy,
@@ -371,4 +372,13 @@ class InferenceClient(object):
         return self.client.get(
             path=f"{self._config.base_url}/agent_data/{key}",
             cast_to=Dict[str, str],
+        )
+
+    def create_langchain_chat_model(self, metadata_provider: str, metadata_model: str) -> LangchainChatModel:
+        """Langchain BaseChatModel interface for inference."""
+        return LangchainChatModel(
+            metadata_provider=metadata_provider,
+            metadata_model=metadata_model,
+            config=self._config,
+            auth=self._auth if self._auth else "",
         )

--- a/nearai/shared/langchain_chat_model.py
+++ b/nearai/shared/langchain_chat_model.py
@@ -1,0 +1,75 @@
+import os
+from functools import cached_property
+from typing import Any, Dict, List, Optional
+
+from langchain_core.callbacks import (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import BaseMessage
+from langchain_core.outputs import ChatResult
+from langchain_openai import ChatOpenAI
+from pydantic import Field
+
+from nearai.shared.client_config import ClientConfig
+from nearai.shared.provider_models import ProviderModels
+
+
+class LangchainChatModel(BaseChatModel):
+    """NEAR AI chat model adapter for Langchain BaseChatModel interface."""
+
+    metadata_provider: str = Field(default="")
+    metadata_model: str = Field(default="")
+
+    # TODO(#796): don't expose this data to agent
+    config: ClientConfig = Field(exclude=True)
+    auth: str = Field(default="", exclude=True)
+
+    @cached_property
+    def provider_models(self) -> ProviderModels:  # noqa: D102
+        return ProviderModels(self.config)
+
+    @cached_property
+    def inference_model(self) -> str:
+        """Returns 'provider::model_full_path'."""
+        _, model_for_inference = self.provider_models.match_provider_model(self.metadata_model, self.metadata_provider)
+        return model_for_inference
+
+    @cached_property
+    def chat_open_ai_model(self) -> ChatOpenAI:  # noqa: D102
+        os.environ["OPENAI_API_KEY"] = self.auth
+        return ChatOpenAI(model=self.inference_model, base_url=self.config.base_url)
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Generate chat model outputs."""
+        return self.chat_open_ai_model._generate(messages=messages, stop=stop, run_manager=run_manager, **kwargs)
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Asynchronously generate chat model outputs."""
+        return await self.chat_open_ai_model._agenerate(messages=messages, stop=stop, run_manager=run_manager, **kwargs)
+
+    @property
+    def _identifying_params(self) -> Dict[str, Any]:
+        """Get the identifying parameters."""
+        return {
+            "metadata_provider": self.metadata_provider,
+            "metadata_model": self.metadata_model,
+        }
+
+    @property
+    def _llm_type(self) -> str:
+        """Get the type of LLM."""
+        return "nearai-chat"

--- a/poetry.lock
+++ b/poetry.lock
@@ -9328,4 +9328,4 @@ vllm = ["torch", "vllm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.12"
-content-hash = "6eda4353db1876f60c533cfc11fc155386e0e3449aae851b893cc3fbe085152f"
+content-hash = "28a70af83cf5bfa020979b988354a0810ec6ebe57adea8c47c86cb15d50315fc"

--- a/poetry.lock
+++ b/poetry.lock
@@ -9328,4 +9328,4 @@ vllm = ["torch", "vllm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.12"
-content-hash = "28a70af83cf5bfa020979b988354a0810ec6ebe57adea8c47c86cb15d50315fc"
+content-hash = "6eda4353db1876f60c533cfc11fc155386e0e3449aae851b893cc3fbe085152f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,8 @@ tweepy = { version = "^4.14.0" }
 rich = "^13.7.0"
 py-near = "^1.1.50"
 loguru = "^0.7.2"
+langchain = "^0.3.4"
+langchain-openai = "^0.2.4"
 
 [project.optional-dependencies]
 # Experiment platform

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,8 +121,6 @@ tweepy = { version = "^4.14.0" }
 rich = "^13.7.0"
 py-near = "^1.1.50"
 loguru = "^0.7.2"
-langchain = "^0.3.4"
-langchain-openai = "^0.2.4"
 
 [project.optional-dependencies]
 # Experiment platform
@@ -300,7 +298,10 @@ module = [
     "chardet.*",
     "botocore.*",
     "shortuuid.*",
-    "py_near.*"
+    "py_near.*",
+    "langchain.*",
+    "langchain_core.*",
+    "langchain_openai.*"
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
Since agent can't access client config (and should not), we'll have to pass inference object friendly for langchain/langgraph libraries from Environment.

This is a temporary step back on our TEE efforts, for a hackathon. After a hackathon I'll have to figure out how to provide inference object without exposing any user data.