### PR TITLE
Another unicode fix (3/4-byte)

### DIFF
--- a/hub/api/v1/models.py
+++ b/hub/api/v1/models.py
@@ -215,12 +215,12 @@ class Message(SQLModel, table=True):
             ]
         if self.content:
             if isinstance(self.content, str):
-                # Filter out non-utf8 characters
+                # Filter out non-utf8 characters (which shouldn't happen!)
                 content = self.content.encode("utf-8", errors="ignore").decode("utf-8", errors="ignore")
 
-                # Regular expression to match only valid UTF-8 characters, because we can't support utf8mb4 charset
+                # Regular expression to match only 1- to 3-byte characters, because something is broken in for 4-byte (utf8mb4) characters
                 # TODO #767: Remove this when we support utf8mb4 charset
-                content = re.sub(r"[^\x00-\xFF]", "", content)
+                content = re.sub(r"[\U00010000-\U0010FFFF]", "", content)
 
                 self.content = [TextContentBlock(text=Text(value=content, annotations=[]), type="text")]
 
@@ -380,7 +380,6 @@ def get_session() -> Iterator[Session]:
 # Constants for file URI prefixes
 FILE_URI_PREFIX = "file::"
 S3_URI_PREFIX = "s3::"
-
 
 SUPPORTED_MIME_TYPES = {
     "text/x-c": [".c"],

--- a/hub/api/v1/models.py
+++ b/hub/api/v1/models.py
@@ -218,7 +218,8 @@ class Message(SQLModel, table=True):
                 # Filter out non-utf8 characters (which shouldn't happen!)
                 content = self.content.encode("utf-8", errors="ignore").decode("utf-8", errors="ignore")
 
-                # Regular expression to match only 1- to 3-byte characters, because something is broken in for 4-byte (utf8mb4) characters
+                # Regular expression to match only 1- to 3-byte characters, because something is broken
+                # for 4-byte (utf8mb4) characters
                 # TODO #767: Remove this when we support utf8mb4 charset
                 content = re.sub(r"[\U00010000-\U0010FFFF]", "", content)
 


### PR DESCRIPTION
Another workaound for #767

Someone on Telegram complained that our platform no longer supports Russian.   Russian letters are in the three-byte space of UTF-8, so if our problem is actually SQLAlchemy + 4-byte unicode, we don't have to mess with the 2-byte and 3-byte stuff.  This change allows those characters while still banning those problematic emojis.

Note: I haven't run this code yet in production.  I couldn't even repro the original bug locally.  So there's no way for me to know whether this new regex works, or causes additional issues.  