### PR TITLE
fix(docs): model full path convention

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -62,7 +62,7 @@ models = client.models.list()
 print(models)
 ```
 
-Different providers have different models. The format is `<provider>::accounts/<provider>/models/<model_name>`. To get all unique providers, do:
+Different providers have different models. The format is `provider::accounts/namespace/models/model_name`. To get all unique providers, do:
 
 ```python
 providers = set([model.id.split("::")[0] for model in models])

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -62,7 +62,7 @@ models = client.models.list()
 print(models)
 ```
 
-Different providers have different models. The format is `provider::account/model_name/model_version`. To get all unique providers, do:
+Different providers have different models. The format is `<provider>::accounts/<provider>/models/<model_name>`. To get all unique providers, do:
 
 ```python
 providers = set([model.id.split("::")[0] for model in models])


### PR DESCRIPTION
### Description

The model IDs (full paths) follow the convention `provider::accounts/namespace/models/model_name`, e.g.  `fireworks::accounts/fireworks/models/qwen2p5-72b-instruct`. The current format in the doc is incorrect. 

Question: Why is the model version missing?

### Reference

The list of all available models:

```
fireworks::accounts/yi-01-ai/models/yi-large
fireworks::accounts/mels-e0299e/models/aiderlm-v0
fireworks::accounts/fireworks/models/flux-1-schnell-fp8
fireworks::accounts/fireworks/models/flux-1-dev-fp8
fireworks::accounts/fireworks/models/mistral-small-24b-instruct-2501
fireworks::accounts/fireworks/models/deepseek-r1
fireworks::accounts/fireworks/models/mixtral-8x22b-instruct
fireworks::accounts/fireworks/models/llama-v3-8b-instruct
fireworks::accounts/fireworks/models/deepseek-v3
fireworks::accounts/fireworks/models/qwen-qwq-32b-preview
fireworks::accounts/fireworks/models/llama-v3p1-405b-instruct
fireworks::accounts/fireworks/models/llama-v3p1-8b-instruct
fireworks::accounts/fireworks/models/llama-v3-8b-instruct-hf
fireworks::accounts/fireworks/models/llama-v3p2-3b-instruct
fireworks::accounts/fireworks/models/qwen2p5-72b-instruct
fireworks::accounts/fireworks/models/llama-v3p1-405b-instruct-long
fireworks::accounts/fireworks/models/llama-v3p1-70b-instruct
fireworks::accounts/fireworks/models/llama-v3-70b-instruct
fireworks::accounts/fireworks/models/llama-v3p2-90b-vision-instruct
fireworks::accounts/fireworks/models/llama-v3p3-70b-instruct
fireworks::accounts/fireworks/models/qwen2p5-coder-32b-instruct
fireworks::accounts/fireworks/models/qwen2-vl-72b-instruct
fireworks::accounts/fireworks/models/llama-v3p2-11b-vision-instruct
fireworks::accounts/fireworks/models/llama-guard-3-8b
fireworks::accounts/fireworks/models/phi-3-vision-128k-instruct
fireworks::accounts/sentientfoundation/models/dobby-mini-leashed-llama-3-1-8b
fireworks::accounts/sentientfoundation/models/dobby-mini-unhinged-llama-3-1-8b
fireworks::accounts/marco-0dece6/models/state-transition-llama3p1
fireworks::accounts/fireworks/models/mixtral-8x7b-instruct
fireworks::accounts/fireworks/models/mythomax-l2-13b
fireworks::accounts/guzmanesneider75-94d6ba/models/tsr3
fireworks::accounts/carlos-0f74b3/models/service-emergency-classifier-llama3-8b-instruct
```
