### PR TITLE
Add contact us button to home page and footer for hub

### DIFF
--- a/hub/demo/src/app/page.tsx
+++ b/hub/demo/src/app/page.tsx
@@ -386,7 +386,7 @@ export default function HomePage() {
                 title: 'Contact Us',
                 description: 'Let us know how we can support your project',
                 label: 'Get In Touch',
-                href: 'https://airtable.com/app8AKPnbj3GfqOyL/pag00hgyw36G6zNau/form',
+                href: 'https://airtable.com/appc0ZVhbKj8hMLvH/pag4dQKP3KF3qrTFo/form',
                 target: '_blank',
               },
               {

--- a/hub/demo/src/app/page.tsx
+++ b/hub/demo/src/app/page.tsx
@@ -22,7 +22,6 @@ import {
   Check,
   CloudCheck,
   CodeBlock,
-  Database,
   DownloadSimple,
   GitFork,
   HandCoins,
@@ -30,6 +29,7 @@ import {
   Lightning,
   LockKey,
   MagnifyingGlass,
+  PaperPlaneTilt,
   TwitterLogo,
   UserCircle,
   XLogo,
@@ -371,28 +371,29 @@ export default function HomePage() {
                 icon: <BookOpenText weight="duotone" />,
                 title: 'Documentation',
                 description: 'Get started with our infrastructure',
-                link: 'Learn More',
+                label: 'Learn More',
                 href: 'https://docs.near.ai',
               },
               {
                 icon: <ChartBar weight="duotone" />,
                 title: 'Evaluations',
                 description: 'Understand our evaluation metrics',
-                link: 'Explore',
+                label: 'Explore',
                 href: '/evaluations',
               },
               {
-                icon: <Database weight="duotone" />,
-                title: 'Datasets',
-                description: 'Contribute to training and evaluation data',
-                link: 'Browse',
-                href: '/datasets',
+                icon: <PaperPlaneTilt weight="duotone" />,
+                title: 'Contact Us',
+                description: 'Let us know how we can support your project',
+                label: 'Get In Touch',
+                href: 'https://airtable.com/app8AKPnbj3GfqOyL/pag00hgyw36G6zNau/form',
+                target: '_blank',
               },
               {
                 icon: <ChatCircle weight="duotone" />,
                 title: 'Community',
                 description: 'Connect with other researchers',
-                link: 'Join',
+                label: 'Join',
                 href: 'https://t.me/nearaialpha',
                 target: '_blank',
               },
@@ -404,7 +405,7 @@ export default function HomePage() {
                 </Text>
                 <Text color="sand-11">{resource.description}</Text>
                 <Button
-                  label={resource.link}
+                  label={resource.label}
                   variant="secondary"
                   fill="outline"
                   iconRight={

--- a/hub/demo/src/components/Footer.tsx
+++ b/hub/demo/src/components/Footer.tsx
@@ -50,7 +50,7 @@ export const Footer = ({ conditional }: Props) => {
           </Text>
 
           <Text
-            href="https://airtable.com/app8AKPnbj3GfqOyL/pag00hgyw36G6zNau/form"
+            href="https://airtable.com/appc0ZVhbKj8hMLvH/pag4dQKP3KF3qrTFo/form"
             target="_blank"
             size="text-xs"
             color="sand-11"

--- a/hub/demo/src/components/Footer.tsx
+++ b/hub/demo/src/components/Footer.tsx
@@ -50,6 +50,15 @@ export const Footer = ({ conditional }: Props) => {
           </Text>
 
           <Text
+            href="https://airtable.com/app8AKPnbj3GfqOyL/pag00hgyw36G6zNau/form"
+            target="_blank"
+            size="text-xs"
+            color="sand-11"
+          >
+            Contact Us
+          </Text>
+
+          <Text
             href="/terms-and-conditions.pdf"
             target="_blank"
             size="text-xs"


### PR DESCRIPTION
From Erick Todd on Slack:

> This onboarding form is ready to be posted on the [near.ai](http://near.ai/) home page as well as the [app.near.ai](http://app.near.ai/) page with a "Get in contact with us" button

- Added contact us button to home page
- Added contact us link to footer

<img width="949" alt="Screenshot 2025-02-07 at 9 21 42 AM" src="https://github.com/user-attachments/assets/241d98cf-312b-4b60-adf8-3de1d7048c3a" />
