### PR TITLE
fix: Removed unnecessary retries in HUB

### DIFF
--- a/aws_runner/frameworks/requirements-base.txt
+++ b/aws_runner/frameworks/requirements-base.txt
@@ -8,8 +8,8 @@ pydantic >=2.8.2
 typing-extensions >= 4.7.1
 psutil >= 5.9.5
 boto3 >= 1.35.3
-litellm >= 1.41.0
-openai == 1.51.2
+litellm >= 1.60.5
+openai == 1.61.0
 py-near >= 1.1.50
 loguru == 0.7.2
 ed25519 == 1.5

--- a/hub/NGINX_CONFIG.md
+++ b/hub/NGINX_CONFIG.md
@@ -9,7 +9,7 @@ proxy_connect_timeout 600s;       # Set the maximum time NGINX waits to establis
 proxy_send_timeout 600s;          # Set the maximum time NGINX waits to send data to the upstream server
 ```
 
-Disable retries to prevent unnecessary retries and potential cascading failures
+Disable retries to prevent unnecessary retries and potential cascading failures.
 These settings ensure that NGINX will not attempt to forward a request to the next upstream server if the first one fails:
 
 ```

--- a/hub/NGINX_CONFIG.md
+++ b/hub/NGINX_CONFIG.md
@@ -1,6 +1,6 @@
 When deploying NEAR AI HUB behind the NGINX proxy, configure the following parameters to ensure smooth operation:
 
-Increase the timeouts to prevent 502 Bad Gateway errors for long-running agent processes
+Increase the timeouts to prevent 502 Bad Gateway errors for long-running agent processes.
 Setting these variables ensures that requests with long processing times (over 60 seconds) are not prematurely terminated:
 
 ```

--- a/hub/NGINX_CONFIG.md
+++ b/hub/NGINX_CONFIG.md
@@ -1,0 +1,25 @@
+When deploying NEAR AI HUB behind the NGINX proxy, configure the following parameters to ensure smooth operation:
+
+Increase the timeouts to prevent 502 Bad Gateway errors for long-running agent processes
+Setting these variables ensures that requests with long processing times (over 60 seconds) are not prematurely terminated:
+
+```
+proxy_read_timeout 600s;          # Allow the NGINX proxy to wait up to 600 seconds for the response from the upstream server
+proxy_connect_timeout 600s;       # Set the maximum time NGINX waits to establish a connection to the upstream server
+proxy_send_timeout 600s;          # Set the maximum time NGINX waits to send data to the upstream server
+```
+
+Disable retries to prevent unnecessary retries and potential cascading failures
+These settings ensure that NGINX will not attempt to forward a request to the next upstream server if the first one fails:
+
+```
+proxy_next_upstream off;          # Disables retrying the request on the next upstream server if it fails
+proxy_next_upstream_tries 1;      # Limits retries to 1 (if any), effectively avoiding additional retries
+```
+
+Adjust buffer sizes for better handling of large responses from the upstream server
+```
+proxy_buffer_size 128k;           # Set the buffer size for the initial response from the upstream server
+proxy_buffers 4 256k;             # Set the number and size of buffers for the response
+proxy_busy_buffers_size 256k;     # Set the maximum size of buffers that can be used for busy responses
+```

--- a/hub/api/v1/agent_routes.py
+++ b/hub/api/v1/agent_routes.py
@@ -4,10 +4,12 @@ from typing import Any, Dict, Optional, Union
 
 import boto3
 import requests
+from botocore.config import Config
 from fastapi import APIRouter, Depends, HTTPException
 from nearai.agents.local_runner import LocalRunner
 from nearai.clients.lambda_client import LambdaWrapper
 from nearai.shared.auth_data import AuthData
+from nearai.shared.client_config import DEFAULT_TIMEOUT
 from pydantic import BaseModel, Field
 
 from hub.api.v1.auth import AuthToken, get_auth
@@ -93,7 +95,8 @@ def invoke_agent_via_url(custom_runner_url, agents, thread_id, run_id, auth: Aut
 
 
 def invoke_agent_via_lambda(function_name, agents, thread_id, run_id, auth: AuthToken, params):
-    wrapper = LambdaWrapper(boto3.client("lambda", region_name="us-east-2"))
+    config = Config(read_timeout=DEFAULT_TIMEOUT, connect_timeout=DEFAULT_TIMEOUT, retries=None)
+    wrapper = LambdaWrapper(boto3.client("lambda", region_name="us-east-2", config=config), thread_id, run_id)
     auth_data = auth.model_dump()
 
     if auth_data["nonce"]:

--- a/hub/api/v1/models.py
+++ b/hub/api/v1/models.py
@@ -269,6 +269,11 @@ class Thread(SQLModel, table=True):
 
     def to_openai(self) -> OpenAITThread:
         """Convert to OpenAI Thread."""
+        # Assuming agent_ids is a list, join it into a string
+        if self.meta_data and "agent_ids" in self.meta_data:
+            agent_ids = ",".join(self.meta_data["agent_ids"])  # Join the list into a single string
+            self.meta_data["agent_ids"] = agent_ids
+
         return OpenAITThread(
             metadata=self.meta_data,
             tool_resources=None,  # TODO: Implement conversion

--- a/hub/demo/src/lib/models.ts
+++ b/hub/demo/src/lib/models.ts
@@ -287,15 +287,18 @@ export const agentAddSecretsRequestModel = z.object({
   reloadAgentMessage: z.string().nullish(),
 });
 
-export const threadMetadataModel = z.intersection(
-  z
-    .object({
-      agent_ids: z.string().array().default([]),
-      topic: z.string(),
-    })
-    .partial(),
-  z.record(z.string(), z.unknown()),
-);
+export const threadMetadataModel = z
+  .object({
+    agent_ids: z.preprocess(
+      (val) =>
+        typeof val === 'string'
+          ? val.split(',').map((item) => item.trim())
+          : val,
+      z.array(z.string()).default([]),
+    ),
+    topic: z.string().optional(),
+  })
+  .passthrough();
 
 export const threadModel = z.object({
   id: z.string(),

--- a/hub/demo/src/stores/threads.ts
+++ b/hub/demo/src/stores/threads.ts
@@ -96,7 +96,7 @@ const store: StateCreator<ThreadsStore> = (set, get) => ({
 
     const updatedThread: Thread = {
       created_at: 0,
-      metadata: {},
+      metadata: { agent_ids: [], topic: '' },
       object: '',
       ...data,
       run: run ?? existingThread?.run,

--- a/hub/tasks/schedule.py
+++ b/hub/tasks/schedule.py
@@ -106,17 +106,16 @@ async def lifespan(app):
 
     if read_scheduled_runs:
         job = partial(process_due_tasks, auth_token)
-        await job()
         get_async_scheduler().add_job(job, IntervalTrigger(seconds=1), name="schedule_run")
 
     if read_near_events:
         process_near_events_initial_state()
         job = partial(near_events_task, auth_token)
-        await job()
         get_async_scheduler().add_job(job, IntervalTrigger(seconds=1), name="near_events")
 
     if read_x_events:
         job = partial(x_events_task, auth_token)
+        # immediately run the job instead of waiting for the 2 minutes interval
         await job()
         get_async_scheduler().add_job(job, IntervalTrigger(seconds=120), name="x_events")
 

--- a/hub/tasks/scheduler.py
+++ b/hub/tasks/scheduler.py
@@ -7,7 +7,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from hub.api.v1.models import engine
 
 scheduler = BackgroundScheduler()
-logging.getLogger("apscheduler").setLevel(logging.DEBUG)
+logging.getLogger("apscheduler").setLevel(logging.WARNING)
 
 async_scheduler = AsyncIOScheduler()
 

--- a/nearai/agents/environment.py
+++ b/nearai/agents/environment.py
@@ -45,7 +45,7 @@ from nearai.shared.models import (
     ExpiresAfter,
     GitHubSource,
     GitLabSource,
-    StaticFileChunkingStrategyParam,
+    StaticFileChunkingStrategyObjectParam,
 )
 from nearai.shared.near.sign import (
     CompletionSignaturePayload,
@@ -368,7 +368,7 @@ class Environment(object):
             file_ids: list,
             expires_after: Union[ExpiresAfter, NotGiven] = NOT_GIVEN,
             chunking_strategy: Union[
-                AutoFileChunkingStrategyParam, StaticFileChunkingStrategyParam, NotGiven
+                AutoFileChunkingStrategyParam, StaticFileChunkingStrategyObjectParam, NotGiven
             ] = NOT_GIVEN,
             metadata: Optional[Dict[str, str]] = None,
         ) -> VectorStore:

--- a/nearai/clients/debug_client.py
+++ b/nearai/clients/debug_client.py
@@ -1,0 +1,50 @@
+# This script creates a simple HTTP server that logs all incoming requests.
+# May be used to replace NEAR AI provider and debug client communication.
+
+# How to use:
+# 1. Deploy local NEAR AI HUB instance
+# 1. Update /hub/api/v1/completions.py to use the new provider URL (e.g. http://127.0.0.1:5000)
+# 2. Start the hub and run the script:
+#    python debug_client.py
+
+import threading
+import time
+
+import BaseHTTPServer  # type: ignore
+
+
+class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+    # This handler will catch all types of HTTP requests (GET, POST, PUT, DELETE, PATCH, OPTIONS)
+    # and log the request details including timestamp, method, path, headers, and body.
+    def do_ANY(self):  # noqa: N815, N802
+        """Handle any type of request."""
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length) if length else ""
+        timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
+        print(
+            "[{timestamp}] [{method}] {path} - Headers: {headers} - Body: {body}".format(
+                timestamp=timestamp, method=self.command, path=self.path, headers=dict(self.headers), body=body
+            )
+        )
+        while True:
+            pass
+
+    do_GET = do_POST = do_PUT = do_DELETE = do_PATCH = do_OPTIONS = do_ANY  # noqa: N815
+
+
+class ThreadedHTTPServer(BaseHTTPServer.HTTPServer):
+    def process_request(self, request, client_address):
+        """Start a new thread to process the request."""
+        thread = threading.Thread(target=self._handle_request, args=(request, client_address))
+        thread.daemon = True
+        thread.start()
+
+    def _handle_request(self, request, client_address):
+        """Handle one request by instantiating the handler class."""
+        self.RequestHandlerClass(request, client_address, self)
+
+
+if __name__ == "__main__":
+    server = ThreadedHTTPServer(("0.0.0.0", 5000), RequestHandler)
+    print("Starting server on port 5000...")
+    server.serve_forever()

--- a/nearai/shared/client_config.py
+++ b/nearai/shared/client_config.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from nearai.shared.auth_data import AuthData
 
-DEFAULT_TIMEOUT = 60 * 5
+DEFAULT_TIMEOUT = 60 * 10
 DEFAULT_MAX_RETRIES = 1
 DEFAULT_MODEL_TEMPERATURE = 1.0
 DEFAULT_MODEL_MAX_TOKENS = 16384

--- a/nearai/shared/inference_client.py
+++ b/nearai/shared/inference_client.py
@@ -30,7 +30,7 @@ from nearai.shared.models import (
     GitLabSource,
     SimilaritySearch,
     SimilaritySearchFile,
-    StaticFileChunkingStrategyParam,
+    StaticFileChunkingStrategyObjectParam,
 )
 from nearai.shared.provider_models import ProviderModels
 
@@ -227,7 +227,9 @@ class InferenceClient(object):
         name: str,
         file_ids: List[str],
         expires_after: Union[ExpiresAfter, NotGiven] = NOT_GIVEN,
-        chunking_strategy: Union[AutoFileChunkingStrategyParam, StaticFileChunkingStrategyParam, NotGiven] = NOT_GIVEN,
+        chunking_strategy: Union[
+            AutoFileChunkingStrategyParam, StaticFileChunkingStrategyObjectParam, NotGiven
+        ] = NOT_GIVEN,
         metadata: Optional[Dict[str, str]] = None,
     ) -> VectorStore:
         """Creates Vector Store.

--- a/nearai/shared/models.py
+++ b/nearai/shared/models.py
@@ -32,6 +32,11 @@ class StaticFileChunkingStrategyParam(TypedDict, total=False):
     """
 
 
+class StaticFileChunkingStrategyObjectParam(TypedDict, total=False):
+    static: Required[StaticFileChunkingStrategyParam]
+    type: Required[Literal["static"]]
+
+
 class ChunkingStrategy(BaseModel):
     """Defines the chunking strategy for vector stores."""
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3188,25 +3188,25 @@ test = ["coverage", "pytest", "pytest-cov"]
 
 [[package]]
 name = "litellm"
-version = "1.57.4"
+version = "1.60.8"
 description = "Library to easily interface with LLM API providers"
 optional = false
 python-versions = "!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,>=3.8"
 groups = ["main"]
 markers = "python_version <= \"3.11\""
 files = [
-    {file = "litellm-1.57.4-py3-none-any.whl", hash = "sha256:afe48924d8a36db801018970a101622fce33d117fe9c54441c0095c491511abb"},
-    {file = "litellm-1.57.4.tar.gz", hash = "sha256:747a870ddee9c71f9560fc68ad02485bc1008fcad7d7a43e87867a59b8ed0669"},
+    {file = "litellm-1.60.8-py3-none-any.whl", hash = "sha256:260bdcc9749c769f1a84dc927abe7c91f6294a97da05abc6b513c5dd2dcf17a1"},
+    {file = "litellm-1.60.8.tar.gz", hash = "sha256:4a0aca9bd226d727ca4a41aaf8722f825fc10cf33f37a177a3cceb4ee2c442d8"},
 ]
 
 [package.dependencies]
 aiohttp = "*"
 click = "*"
-httpx = ">=0.23.0,<0.28.0"
+httpx = ">=0.23.0"
 importlib-metadata = ">=6.8.0"
 jinja2 = ">=3.1.2,<4.0.0"
 jsonschema = ">=4.22.0,<5.0.0"
-openai = ">=1.55.3"
+openai = ">=1.61.0"
 pydantic = ">=2.0.0,<3.0.0"
 python-dotenv = ">=0.2.0"
 tiktoken = ">=0.7.0"
@@ -3214,7 +3214,7 @@ tokenizers = "*"
 
 [package.extras]
 extra-proxy = ["azure-identity (>=1.15.0,<2.0.0)", "azure-keyvault-secrets (>=4.8.0,<5.0.0)", "google-cloud-kms (>=2.21.3,<3.0.0)", "prisma (==0.11.0)", "resend (>=0.8.0,<0.9.0)"]
-proxy = ["PyJWT (>=2.8.0,<3.0.0)", "apscheduler (>=3.10.4,<4.0.0)", "backoff", "cryptography (>=43.0.1,<44.0.0)", "fastapi (>=0.115.5,<0.116.0)", "fastapi-sso (>=0.16.0,<0.17.0)", "gunicorn (>=22.0.0,<23.0.0)", "orjson (>=3.9.7,<4.0.0)", "pynacl (>=1.5.0,<2.0.0)", "python-multipart (>=0.0.18,<0.0.19)", "pyyaml (>=6.0.1,<7.0.0)", "rq", "uvicorn (>=0.22.0,<0.23.0)"]
+proxy = ["PyJWT (>=2.8.0,<3.0.0)", "apscheduler (>=3.10.4,<4.0.0)", "backoff", "cryptography (>=43.0.1,<44.0.0)", "fastapi (>=0.115.5,<0.116.0)", "fastapi-sso (>=0.16.0,<0.17.0)", "gunicorn (>=22.0.0,<23.0.0)", "orjson (>=3.9.7,<4.0.0)", "pynacl (>=1.5.0,<2.0.0)", "python-multipart (>=0.0.18,<0.0.19)", "pyyaml (>=6.0.1,<7.0.0)", "rq", "uvicorn (>=0.29.0,<0.30.0)", "uvloop (>=0.21.0,<0.22.0)"]
 
 [[package]]
 name = "llvmlite"
@@ -4684,15 +4684,15 @@ PyYAML = ">=5.1.0"
 
 [[package]]
 name = "openai"
-version = "1.59.3"
+version = "1.61.1"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "python_version <= \"3.11\""
 files = [
-    {file = "openai-1.59.3-py3-none-any.whl", hash = "sha256:b041887a0d8f3e70d1fc6ffbb2bf7661c3b9a2f3e806c04bf42f572b9ac7bc37"},
-    {file = "openai-1.59.3.tar.gz", hash = "sha256:7f7fff9d8729968588edf1524e73266e8593bb6cab09298340efb755755bb66f"},
+    {file = "openai-1.61.1-py3-none-any.whl", hash = "sha256:72b0826240ce26026ac2cd17951691f046e5be82ad122d20a8e1b30ca18bd11e"},
+    {file = "openai-1.61.1.tar.gz", hash = "sha256:ce1851507218209961f89f3520e06726c0aa7d0512386f0f977e3ac3e4f2472e"},
 ]
 
 [package.dependencies]
@@ -9328,4 +9328,4 @@ vllm = ["torch", "vllm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.12"
-content-hash = "a3f1cd3be6ddfa534c08d278a1d582e673a77924bdaff728bf68922ea9d522dc"
+content-hash = "d6b09767a55528371283a54c3284bc2d09791a0cc16aabdb857aa2523efc7ec4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ dependencies = [
     "fastapi>=0.111.0,<0.112.0",
     "fire>=0.6.0,<0.7.0",
     "jinja2>=3.1.4,<4.0.0",
-    "litellm>=1.41.0,<2.0.0",
+    "litellm>=1.60.5,<2.0.0",
     "mypy-boto3>=1.34.147,<2.0.0",
     "mypy-boto3-s3>=1.34.138,<2.0.0",
-    "openai>=1.30.1,<2.0.0",
+    "openai>=1.61.1,<2.0.0",
     "pandas-stubs>=2.2.2.240603,<3.0.0",
     "peft>=0.10.0,<0.11.0",
     "psutil>=5.9.5,<6.0.0",
@@ -73,10 +73,10 @@ flask = { version = "^3.0.3", optional = true }
 gunicorn = { version = "^22.0.0", optional = true }
 jinja2 = "^3.1.4"
 lean-dojo = { version = "^2.1.3", optional = true }
-litellm = "^1.41.0"
+litellm = "^1.60.5"
 mypy-boto3 = "^1.35.70"
 mypy-boto3-s3 = "^1.35.70"
-openai = "^1.30.1"
+openai = "^1.61.1"
 pandas-stubs = "^2.2.2.240603"
 peft = "^0.10.0"
 psutil = "^5.9.5"


### PR DESCRIPTION
feat: openai litellm bumped
fix: UI to support agent_ids in metadata both as string and list of strings
fix: lambda invoke function to respect DEFAULT_TIMEOUT and avoid retries
fix: schedulers to avoid multiple runs on hub start
feat: debug client to replace provider and test client communication
fix: lambda function to get client context to identify invocations
fix: litellm to respect DEFAULT_TIMEOUT and DEFAULT_MAX_RETRIES for openai provider
feat: nginx config doc