### PR TITLE
Remove prefix when computing embedding vectors

### DIFF
--- a/hub/api/v1/vector_stores.py
+++ b/hub/api/v1/vector_stores.py
@@ -374,7 +374,7 @@ async def query_vector_store(vector_store_id: str, request: QueryVectorStoreRequ
             logger.warning(f"Vector store not found: {vector_store_id}")
             raise HTTPException(status_code=404, detail="Vector store not found")
 
-        emb = await generate_embedding(request.query, query=True)
+        emb = await generate_embedding(request.query)
         if request.full_files:
             return sql.similarity_search_full_files(vector_store_id, emb)
         else:

--- a/hub/tasks/embedding_generation.py
+++ b/hub/tasks/embedding_generation.py
@@ -218,8 +218,8 @@ async def generate_embedding(text: str, query: bool = False):
     client = openai.AsyncOpenAI(
         base_url="https://api.fireworks.ai/inference/v1", api_key=os.getenv("FIREWORKS_API_KEY")
     )
-    prefix = "search_query: " if query else "search_document: "
-    response = await client.embeddings.create(input=prefix + text, model=EMBEDDING_MODEL)
+
+    response = await client.embeddings.create(input=text, model=EMBEDDING_MODEL)
     return response.data[0].embedding
 
 

--- a/hub/tasks/embedding_generation.py
+++ b/hub/tasks/embedding_generation.py
@@ -201,7 +201,7 @@ def recursive_split(text: str, chunk_size: int, chunk_overlap: int) -> List[str]
     return [text[:chunk_size]]
 
 
-async def generate_embedding(text: str, query: bool = False):
+async def generate_embedding(text: str):
     """Generate an embedding for the given text using the Nomic AI model.
 
     Args:


### PR DESCRIPTION
This PR removes a prefix that is being prepended to all texts for which we compute an embedding, since in my local tests such prefixes changes drastically the comparisons between "documents' embeddings" and "user query's embedding"

This PR addresses issue #831