### PR TITLE
Fixing initial thread message UI flicker

### DIFF
--- a/hub/demo/src/components/threads/ThreadMessages.tsx
+++ b/hub/demo/src/components/threads/ThreadMessages.tsx
@@ -84,8 +84,6 @@ export const ThreadMessages = ({
     }
   }, [groupedMessages, threadId, scroll]);
 
-  console.log(groupedMessages);
-
   if (!isAuthenticated) {
     return (
       <div className={s.wrapper} data-grow={grow}>
@@ -100,14 +98,11 @@ export const ThreadMessages = ({
 
       <div className={s.messages} ref={messagesRef}>
         {groupedMessages.map((group, groupIndex) => (
-          <Fragment key={group.threadId + groupIndex}>
+          <Fragment key={groupIndex}>
             {group.isRootThread ? (
               <>
                 {group.messages.map((message, messageIndex) => (
-                  <ThreadMessage
-                    message={message}
-                    key={message.role + messageIndex}
-                  />
+                  <ThreadMessage message={message} key={messageIndex} />
                 ))}
               </>
             ) : (
@@ -161,10 +156,7 @@ const Subthread = ({ group }: SubthreadProps) => {
 
           <Accordion.Content style={{ paddingBottom: 0 }}>
             {group.messages.map((message, messageIndex) => (
-              <ThreadMessage
-                message={message}
-                key={message.role + messageIndex}
-              />
+              <ThreadMessage message={message} key={messageIndex} />
             ))}
 
             <Text

--- a/hub/demo/src/hooks/threads.ts
+++ b/hub/demo/src/hooks/threads.ts
@@ -114,7 +114,10 @@ export function useGroupedThreadMessages(
         return;
       } else {
         result.push({
-          isRootThread: message.thread_id === rootThreadId,
+          isRootThread:
+            message.thread_id === rootThreadId ||
+            message.thread_id === '' ||
+            !rootThreadId,
           threadId: message.thread_id,
           messages: [message],
         });


### PR DESCRIPTION
I noticed the UI would quickly switch between a couple states when the user submits the first message to create a new thread - which would cause a quick flicker between UI states. This fixes that.