### PR TITLE
fix: recreate agent files in `temp_dir` for both py and ts cached agents

### DIFF
--- a/docs/agents/env/calling_other_agents.md
+++ b/docs/agents/env/calling_other_agents.md
@@ -3,7 +3,7 @@
 Agents can call other agents to interact with them using the [`run_agent`](../../api.md#nearai.agents.environment.Environment.run_agent) method. To call an agent, we need to provide the agent's account, name, and version. Optionally, we can pass a query to the agent.
 
 ```python
-result = env.run_agent("travel.primitives.near", "trip-organizer", "latest", query="Plan a two-day trip to Buenos Aires", fork_thread=False)
+result = env.run_agent("travel.primitives.near/trip-organizer/latest", query="Plan a two-day trip to Buenos Aires", fork_thread=False)
 print(result)
 
 # thread_312f2ea5e42742c785218106

--- a/docs/agents/registry.md
+++ b/docs/agents/registry.md
@@ -133,4 +133,4 @@ The folder must contain an `agent.py` file, where the agent's logic is written, 
 
 ## Find agents from the agent
 
-* [`find_agents`](../api.md#nearai.agents.environment.Environment.find_agents): Filter agents based on various parameters.
+* [`find_agents`](../api.md#nearai.agents.environment.Environment.find_agents): Find agents based on various parameters.

--- a/docs/agents/registry.md
+++ b/docs/agents/registry.md
@@ -133,4 +133,4 @@ The folder must contain an `agent.py` file, where the agent's logic is written, 
 
 ## Find agents from the agent
 
-* [`filter_agents`](../api.md#nearai.agents.environment.Environment.filter_agents): Filter agents based on various parameters.
+* [`find_agents`](../api.md#nearai.agents.environment.Environment.find_agents): Filter agents based on various parameters.

--- a/hub/api/v1/agent_routes.py
+++ b/hub/api/v1/agent_routes.py
@@ -292,9 +292,9 @@ class FilterAgentsRequest(BaseModel):
     with_capabilities: Optional[bool] = False
 
 
-@run_agent_router.post("/filter_agents", response_model=List[RegistryEntry])
-def filter_agents(request_data: FilterAgentsRequest, auth: AuthToken = Depends(get_auth)) -> List[RegistryEntry]:
-    """Filter agents based on various parameters."""
+@run_agent_router.post("/find_agents", response_model=List[RegistryEntry])
+def find_agents(request_data: FilterAgentsRequest, auth: AuthToken = Depends(get_auth)) -> List[RegistryEntry]:
+    """Find agents based on various parameters."""
     with get_session() as session:
         # Start building the base query
         query = session.query(RegistryEntry)
@@ -311,9 +311,6 @@ def filter_agents(request_data: FilterAgentsRequest, auth: AuthToken = Depends(g
         # Filter by capabilities (if flag is set)
         if request_data.with_capabilities:
             query = query.filter(text("JSON_EXTRACT_JSON(details, 'capabilities') IS NOT NULL"))
-
-        # Print the generated SQL query for debugging
-        print(query.statement.compile(compile_kwargs={"literal_binds": True}))
 
         # Execute query and return results
         filtered_agents = query.all()

--- a/nearai/agents/agent.py
+++ b/nearai/agents/agent.py
@@ -252,7 +252,7 @@ class Agent(object):
 
                 self.ts_runner_dir = ts_runner_sdk_dir
             else:
-                raise ValueError(f"Agent run error: {AGENT_FILENAME_PY} of {AGENT_FILENAME_TS} does not exist")
+                raise ValueError(f"Agent run error: {AGENT_FILENAME_PY} or {AGENT_FILENAME_TS} does not exist")
 
             # cache all agent files in file_cache
             for root, _, files in os.walk(self.temp_dir):

--- a/nearai/agents/environment.py
+++ b/nearai/agents/environment.py
@@ -399,7 +399,7 @@ class Environment(object):
 
         # positional arguments are not allowed because arguments list will be updated
         def find_agents(*, owner_id: Optional[str] = None, with_capabilities: Optional[bool] = False):
-            """Filter agents based on various parameters."""
+            """Find agents based on various parameters."""
             return client.find_agents(owner_id, with_capabilities)
 
         self.find_agents = find_agents

--- a/nearai/agents/environment.py
+++ b/nearai/agents/environment.py
@@ -397,11 +397,12 @@ class Environment(object):
 
         self.add_file_to_vector_store = add_file_to_vector_store
 
-        def filter_agents(owner_id: Optional[str] = None, with_capabilities: Optional[bool] = False):
+        # positional arguments are not allowed because arguments list will be updated
+        def find_agents(*, owner_id: Optional[str] = None, with_capabilities: Optional[bool] = False):
             """Filter agents based on various parameters."""
-            return client.filter_agents(owner_id, with_capabilities)
+            return client.find_agents(owner_id, with_capabilities)
 
-        self.filter_agents = filter_agents
+        self.find_agents = find_agents
 
         def create_vector_store(
             name: str,
@@ -495,9 +496,7 @@ class Environment(object):
         self.get_agent_public_key = get_agent_public_key
 
         def run_agent(
-            owner: str,
-            agent_name: str,
-            version: str,
+            agent_id: str,
             query: Optional[str] = None,
             thread_mode: ThreadMode = ThreadMode.FORK,
             additional_subthread_messages: Optional[List[Message]] = None,
@@ -518,15 +517,14 @@ class Environment(object):
             if query:
                 client.threads_messages_create(thread_id=child_thread_id, content=query, role="user")
 
-            assistant_id = f"{owner}/{agent_name}/{version}"
-            self.add_system_log(f"Running agent {assistant_id}", logging.INFO)
+            self.add_system_log(f"Running agent {agent_id}", logging.INFO)
             parent_run_id = None
             if run_mode == RunMode.WITH_CALLBACK:
                 parent_run_id = self._run_id
             client.run_agent(
                 parent_run_id=parent_run_id,
                 run_on_thread_id=child_thread_id,
-                assistant_id=assistant_id,
+                assistant_id=agent_id,
             )
             self._pending_ext_agent = True
 

--- a/nearai/aws_runner/service.py
+++ b/nearai/aws_runner/service.py
@@ -135,14 +135,10 @@ def load_agent(client, agent, params: dict, additional_path: str = "", verbose=T
     if params["data_source"] == "registry":
         global local_agent_cache
         if agent in local_agent_cache:
-            print(f"Using {agent} from cache")
             full_agent = local_agent_cache[agent]
-
-            if full_agent.agent_language == "ts":
-                full_agent.temp_dir = full_agent.write_agent_files_to_temp(full_agent.agent_files)
-                return full_agent
-            else:
-                return local_agent_cache[agent]
+            full_agent.temp_dir = full_agent.write_agent_files_to_temp(full_agent.agent_files)
+            print(f"Using {agent} from cache in {full_agent.temp_dir}")
+            return full_agent
 
         start_time = time.perf_counter()
         agent_files = client.get_agent(agent)

--- a/nearai/shared/inference_client.py
+++ b/nearai/shared/inference_client.py
@@ -424,10 +424,10 @@ class InferenceClient(object):
             cast_to=Dict[str, str],
         )
 
-    def filter_agents(self, owner_id: Optional[str] = None, with_capabilities: Optional[bool] = False):
+    def find_agents(self, owner_id: Optional[str] = None, with_capabilities: Optional[bool] = False):
         """Filter agents."""
         return self.client.post(
-            path=f"{self._config.base_url}/filter_agents",
+            path=f"{self._config.base_url}/find_agents",
             body={"owner_id": owner_id, "with_capabilities": with_capabilities},
             cast_to=List[Any],
         )


### PR DESCRIPTION
fix: filter_agents -> find_agents renamed
fix: run_agent signature changed to read agent_id instead of namespace, name, version