### PR TITLE
fix: minor typos in `private-ml-sdk.md`

### DIFF
--- a/docs/private-ml-sdk.md
+++ b/docs/private-ml-sdk.md
@@ -24,6 +24,7 @@ Before deployment, NEAR AI verifies both proper hardware configuration and Docke
 After execution, NEAR AI validated security through TEE attestations - cryptographic proofs verify both a secure environment and data/code integrity. 
 
 You can view and verify these attestations yourself or publish them on-chain with NEAR Protocol to allow anyone to verify them. This provides a cryptographically verifiable chain of trust through the entire stack from agent to inference to hardware; all the way down to the certifications from the chip manufacturers.
+
 ---
 
 ## How Can I Use it?

--- a/docs/private-ml-sdk.md
+++ b/docs/private-ml-sdk.md
@@ -5,7 +5,7 @@ Thanks to a combination of cryptographic techniques and secure hardware, NEAR AI
 ![alt text](assets/tee.png)
 <p style="text-align: center; font-size: small; font-style: italic">NEAR AI leverages technology from Intel and NVIDIA to keep your data safe and isolated</p>
 
-To execute the agent securely, NEAR AI uses Intel TDX technology to create a [Confidential Virtual Machine (CVM)](https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/overview.htmlml). This CVM is a virtual machine that runs in an isolated environment within the CPU, where a Docker container containing the agent's code and user data is deployed and executed. 
+To execute an agent securely, NEAR AI uses Intel TDX technology to create a [Confidential Virtual Machine (CVM)](https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/overview.htmlml). This CVM is a virtual machine that runs in an isolated environment within the CPU, where a Docker container containing the agent's code and user data is deployed and executed. 
 
 For model inference, an encrypted communication channel is established using NVIDIA TEE technology, which creates a [Confidential Space within the GPU](https://www.nvidia.com/en-us/data-center/solutions/confidential-computing/). The model runs in this isolated environment, protected from external access.
 
@@ -21,7 +21,7 @@ It's important to note that the CPU and GPU Confidential Spaces operate in **com
 
 Before deployment, NEAR AI verifies both proper hardware configuration and Docker container image hash integrity. This ensures a secure runtime environment and that the exact code being executed matches expectations.
 
-After execution, NEAR AI validated security through TEE attestations - cryptographic proofs verify both a secure environment and data/code integrity. 
+After execution, NEAR AI validates security through TEE attestations - cryptographic proofs verify both a secure environment and data/code integrity. 
 
 You can view and verify these attestations yourself or publish them on-chain with NEAR Protocol to allow anyone to verify them. This provides a cryptographically verifiable chain of trust through the entire stack from agent to inference to hardware; all the way down to the certifications from the chip manufacturers.
 
@@ -29,6 +29,6 @@ You can view and verify these attestations yourself or publish them on-chain wit
 
 ## How Can I Use it?
 
-Right now we are beta testing this technology, but soon we will open it to the public for everyone to use it. In the near future, all agents and models will run in this secure environment, ensuring that your data is always safe and the results are correct.
+Right now we are beta testing this technology, but soon we will open for public use. In the near future, all agents and models will run in this secure environment, ensuring that your data is always safe and the results are correct.
 
-Stay tuned for more updates!
+[Stay tuned for more updates!](https://x.com/near_ai)


### PR DESCRIPTION
- A section in https://docs.near.ai/private-ml-sdk/ was formatted incorrectly (see example below)
- Made a few other typo fixes
- Added link to our nearai twitter profile in the "stay tuned" section

---

![Screenshot 2025-02-16 at 10 39 06 AM](https://github.com/user-attachments/assets/804aad0b-d45a-4d39-8cdc-33bd7bf71329)

![Screenshot 2025-02-16 at 10 35 33 AM](https://github.com/user-attachments/assets/fcdb087e-738e-46ff-854d-1c58ff2ca146)
