### PR TITLE
feat: add optional docs deps in toml

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -82,20 +82,12 @@ If you discover any errors or omissions in our documentation, please open an iss
 
 If you think you can contribute a fix for the issue, please feel free to open a Pull Request.
 
-To preview your changes locally, you will need to install all the dependencies for the documentation, particularly:
-
-- [`mkdocs`](https://www.mkdocs.org/)
-- [`mkdocs-material`](https://squidfunk.github.io/mkdocs-material/)
-- [`mkdocs-autorefs`](https://pypi.org/project/mkdocs-autorefs/)
-- [`mkdocs-minify-plugin`](https://github.com/byrnereese/mkdocs-minify-plugin)
-- [`mkdocsstrings`](https://mkdocstrings.github.io/)
-
-All these dependencies can be easily installed through `pip` or `poetry`:
+To preview your changes locally, you will need to install all the dependencies for the documentation which can be easily installed through `pip` or `poetry`:
 
 === "pip"
 
       ```bash
-      pip install mkdocs mkdocs-material mkdocs-autorefs mkdocs-minify-plugin "mkdocstrings[python]" "mkdocs-material[imaging]"
+      pip install -e ".[docs]"
       ```
 
 === "poetry"

--- a/poetry.lock
+++ b/poetry.lock
@@ -349,7 +349,7 @@ version = "2.16.0"
 description = "Internationalization utilities"
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "babel-2.16.0-py3-none-any.whl", hash = "sha256:368b5b98b37c06b7daf6696391c3240c938b37767d4584413e8438c5c435fa8b"},
@@ -1037,7 +1037,7 @@ version = "1.7.1"
 description = "cffi-based cairo bindings for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "cairocffi-1.7.1-py3-none-any.whl", hash = "sha256:9803a0e11f6c962f3b0ae2ec8ba6ae45e957a146a004697a1ac1bbf16b073b3f"},
@@ -1058,7 +1058,7 @@ version = "2.7.1"
 description = "A Simple SVG Converter based on Cairo"
 optional = false
 python-versions = ">=3.5"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "CairoSVG-2.7.1-py3-none-any.whl", hash = "sha256:8a5222d4e6c3f86f1f7046b63246877a63b49923a1cd202184c3a634ef546b3b"},
@@ -1343,7 +1343,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "(platform_system == \"Windows\" or sys_platform == \"win32\" or os_name == \"nt\") and python_version <= \"3.11\"", dev = "python_version <= \"3.11\"", docs = "python_version <= \"3.11\"", test = "python_version <= \"3.11\" and sys_platform == \"win32\""}
+markers = {main = "python_version <= \"3.11\"", dev = "python_version <= \"3.11\"", docs = "python_version <= \"3.11\"", test = "python_version <= \"3.11\" and sys_platform == \"win32\""}
 
 [[package]]
 name = "colorful"
@@ -1457,7 +1457,7 @@ version = "0.9.5"
 description = "A python port of YUI CSS Compressor"
 optional = false
 python-versions = "*"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "csscompressor-0.9.5.tar.gz", hash = "sha256:afa22badbcf3120a4f392e4d22f9fff485c044a1feda4a950ecc5eba9dd31a05"},
@@ -1469,7 +1469,7 @@ version = "0.7.0"
 description = "CSS selectors for Python ElementTree"
 optional = false
 python-versions = ">=3.7"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "cssselect2-0.7.0-py3-none-any.whl", hash = "sha256:fd23a65bfd444595913f02fc71f6b286c29261e354c41d722ca7a261a49b5969"},
@@ -1562,7 +1562,7 @@ version = "0.7.1"
 description = "XML bomb protection for Python stdlib modules"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
@@ -2139,7 +2139,7 @@ version = "2.1.0"
 description = "Copy your docs directly to the gh-pages branch."
 optional = false
 python-versions = "*"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343"},
@@ -2353,7 +2353,7 @@ version = "1.5.4"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "griffe-1.5.4-py3-none-any.whl", hash = "sha256:ed33af890586a5bebc842fcb919fc694b3dc1bc55b7d9e0228de41ce566b4a1d"},
@@ -2474,7 +2474,7 @@ version = "0.1.13"
 description = "An HTML Minifier"
 optional = false
 python-versions = "*"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "htmlmin2-0.1.13-py3-none-any.whl", hash = "sha256:75609f2a42e64f7ce57dbff28a39890363bde9e7e5885db633317efbdf8c79a2"},
@@ -2979,7 +2979,7 @@ version = "3.0.1"
 description = "JavaScript minifier."
 optional = false
 python-versions = "*"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "jsmin-3.0.1.tar.gz", hash = "sha256:c0959a121ef94542e807a674142606f7e90214a2b3d1eb17300244bbb5cc2bfc"},
@@ -3470,7 +3470,7 @@ version = "3.7"
 description = "Python implementation of John Gruber's Markdown."
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "Markdown-3.7-py3-none-any.whl", hash = "sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803"},
@@ -3690,7 +3690,7 @@ version = "1.3.4"
 description = "A deep merge function for 🐍."
 optional = false
 python-versions = ">=3.6"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"},
@@ -3703,7 +3703,7 @@ version = "1.6.1"
 description = "Project documentation with Markdown."
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e"},
@@ -3736,7 +3736,7 @@ version = "1.2.0"
 description = "Automatically link across pages in MkDocs."
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "mkdocs_autorefs-1.2.0-py3-none-any.whl", hash = "sha256:d588754ae89bd0ced0c70c06f58566a4ee43471eeeee5202427da7de9ef85a2f"},
@@ -3754,7 +3754,7 @@ version = "3.0.2"
 description = "Mkdocs plugin that allow to inject external markdown or markdown section from given url"
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "mkdocs-embed-external-markdown-3.0.2.tar.gz", hash = "sha256:9a3d14a9cc6efb4201175530f277e84da472a576772db264a3b19570cf266317"},
@@ -3774,7 +3774,7 @@ version = "1.0.2"
 description = "A mkdocs plugin that lets you exclude files or trees."
 optional = false
 python-versions = "*"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "mkdocs-exclude-1.0.2.tar.gz", hash = "sha256:ba6fab3c80ddbe3fd31d3e579861fd3124513708271180a5f81846da8c7e2a51"},
@@ -3789,7 +3789,7 @@ version = "0.2.0"
 description = "MkDocs extension that lists all dependencies according to a mkdocs.yml file"
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134"},
@@ -3808,7 +3808,7 @@ version = "9.5.49"
 description = "Documentation that simply works"
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "mkdocs_material-9.5.49-py3-none-any.whl", hash = "sha256:c3c2d8176b18198435d3a3e119011922f3e11424074645c24019c2dcf08a360e"},
@@ -3841,7 +3841,7 @@ version = "1.3.1"
 description = "Extension pack for Python Markdown and MkDocs Material."
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31"},
@@ -3854,7 +3854,7 @@ version = "0.8.0"
 description = "An MkDocs plugin to minify HTML, JS or CSS files prior to being written to disk"
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "mkdocs-minify-plugin-0.8.0.tar.gz", hash = "sha256:bc11b78b8120d79e817308e2b11539d790d21445eb63df831e393f76e52e753d"},
@@ -3873,7 +3873,7 @@ version = "1.2.2"
 description = "A MkDocs plugin for dynamic page redirects to prevent broken links"
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "mkdocs_redirects-1.2.2-py3-none-any.whl", hash = "sha256:7dbfa5647b79a3589da4401403d69494bd1f4ad03b9c15136720367e1f340ed5"},
@@ -3889,7 +3889,7 @@ version = "0.1.5"
 description = "Define your own hooks for mkdocs, without having to create a new package."
 optional = false
 python-versions = "*"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "mkdocs-simple-hooks-0.1.5.tar.gz", hash = "sha256:dddbdf151a18723c9302a133e5cf79538be8eb9d274e8e07d2ac3ac34890837c"},
@@ -3903,12 +3903,29 @@ mkdocs = ">=1.2"
 test = ["pytest (>=4.0)", "pytest-cov"]
 
 [[package]]
+name = "mkdocs-snippets"
+version = "1.3.0"
+description = "Snippets for MkDocs"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "python_version <= \"3.11\" and extra == \"docs\""
+files = [
+    {file = "mkdocs-snippets-1.3.0.tar.gz", hash = "sha256:5af2616ee893c32234007e3d06014c730903a2f73af5c99c529486a1c19b6d6c"},
+    {file = "mkdocs_snippets-1.3.0-py3-none-any.whl", hash = "sha256:c217731ccf3f7e0269e77ab1f1e7bffe5d0de4671da1ef7134bd35896810bcc7"},
+]
+
+[package.dependencies]
+mkdocs = ">=1.0.4"
+pyyaml = ">=6.0"
+
+[[package]]
 name = "mkdocstrings"
 version = "0.25.2"
 description = "Automatic documentation from sources, for MkDocs."
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "mkdocstrings-0.25.2-py3-none-any.whl", hash = "sha256:9e2cda5e2e12db8bb98d21e3410f3f27f8faab685a24b03b06ba7daa5b92abfc"},
@@ -3938,7 +3955,7 @@ version = "1.10.9"
 description = "A Python handler for mkdocstrings."
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "mkdocstrings_python-1.10.9-py3-none-any.whl", hash = "sha256:cbe98710a6757dfd4dff79bf36cb9731908fb4c69dd2736b15270ae7a488243d"},
@@ -4811,7 +4828,7 @@ version = "0.5.7"
 description = "Divides large result sets into pages for easier browsing"
 optional = false
 python-versions = "*"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591"},
@@ -4955,7 +4972,7 @@ version = "0.12.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
@@ -5891,7 +5908,7 @@ version = "10.13"
 description = "Extension pack for Python Markdown."
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "pymdown_extensions-10.13-py3-none-any.whl", hash = "sha256:80bc33d715eec68e683e04298946d47d78c7739e79d808203df278ee8ef89428"},
@@ -6225,7 +6242,7 @@ version = "0.1"
 description = "A custom YAML tag for referencing environment variables in YAML files. "
 optional = false
 python-versions = ">=3.6"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "pyyaml_env_tag-0.1-py3-none-any.whl", hash = "sha256:af31106dec8a4d68c60207c1886031cbf839b68aa7abccdb19868200532c2069"},
@@ -7631,7 +7648,7 @@ version = "1.4.0"
 description = "A tiny CSS parser"
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289"},
@@ -8583,7 +8600,7 @@ version = "6.0.0"
 description = "Filesystem events monitoring"
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26"},
@@ -8725,7 +8742,7 @@ version = "0.5.1"
 description = "Character encoding aliases for legacy web content"
 optional = false
 python-versions = "*"
-groups = ["docs"]
+groups = ["main", "docs"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
@@ -9319,6 +9336,7 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 type = ["pytest-mypy"]
 
 [extras]
+docs = ["mkdocs", "mkdocs-embed-external-markdown", "mkdocs-exclude", "mkdocs-material", "mkdocs-minify-plugin", "mkdocs-redirects", "mkdocs-simple-hooks", "mkdocs-snippets", "mkdocstrings", "mkdocstrings-python", "pillow"]
 explatform = ["fabric", "flask", "gunicorn", "requests", "shortuuid"]
 hub = ["apscheduler", "chardet", "cryptography", "fastapi", "fastapi-cli", "openpyxl", "pypdf", "python-docx", "python-dotenv", "python-pptx", "shortuuid", "sqlmodel", "tweepy"]
 lean = ["lean-dojo"]
@@ -9328,4 +9346,4 @@ vllm = ["torch", "vllm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.12"
-content-hash = "d6b09767a55528371283a54c3284bc2d09791a0cc16aabdb857aa2523efc7ec4"
+content-hash = "64d3c047cbdf72c7ab80dc612a8da846963e0b5d231e1efb1e27d50b0542f07b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3903,23 +3903,6 @@ mkdocs = ">=1.2"
 test = ["pytest (>=4.0)", "pytest-cov"]
 
 [[package]]
-name = "mkdocs-snippets"
-version = "1.3.0"
-description = "Snippets for MkDocs"
-optional = true
-python-versions = ">=3.7"
-groups = ["main"]
-markers = "python_version <= \"3.11\" and extra == \"docs\""
-files = [
-    {file = "mkdocs-snippets-1.3.0.tar.gz", hash = "sha256:5af2616ee893c32234007e3d06014c730903a2f73af5c99c529486a1c19b6d6c"},
-    {file = "mkdocs_snippets-1.3.0-py3-none-any.whl", hash = "sha256:c217731ccf3f7e0269e77ab1f1e7bffe5d0de4671da1ef7134bd35896810bcc7"},
-]
-
-[package.dependencies]
-mkdocs = ">=1.0.4"
-pyyaml = ">=6.0"
-
-[[package]]
 name = "mkdocstrings"
 version = "0.25.2"
 description = "Automatic documentation from sources, for MkDocs."
@@ -9336,7 +9319,7 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 type = ["pytest-mypy"]
 
 [extras]
-docs = ["mkdocs", "mkdocs-embed-external-markdown", "mkdocs-exclude", "mkdocs-material", "mkdocs-minify-plugin", "mkdocs-redirects", "mkdocs-simple-hooks", "mkdocs-snippets", "mkdocstrings", "mkdocstrings-python", "pillow"]
+docs = ["mkdocs", "mkdocs-embed-external-markdown", "mkdocs-exclude", "mkdocs-material", "mkdocs-minify-plugin", "mkdocs-redirects", "mkdocs-simple-hooks", "mkdocstrings", "mkdocstrings-python", "pillow"]
 explatform = ["fabric", "flask", "gunicorn", "requests", "shortuuid"]
 hub = ["apscheduler", "chardet", "cryptography", "fastapi", "fastapi-cli", "openpyxl", "pypdf", "python-docx", "python-dotenv", "python-pptx", "shortuuid", "sqlmodel", "tweepy"]
 lean = ["lean-dojo"]
@@ -9346,4 +9329,4 @@ vllm = ["torch", "vllm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.12"
-content-hash = "64d3c047cbdf72c7ab80dc612a8da846963e0b5d231e1efb1e27d50b0542f07b"
+content-hash = "82fc8291d14ce597ca69baa68e841b73d88149f68dc087cad3293f877df7e577"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,19 @@ hub = [
 torch = ["torch", "torchao", "torchtune"]
 vllm = ["vllm", "torch"]
 lean = ["lean-dojo"]
+docs = [
+    "mkdocs>=1.6.0",
+    "pillow>=10.4.0",
+    "mkdocs-minify-plugin>=0.8.0",
+    "mkdocstrings>=0.25.2",
+    "mkdocstrings-python>=1.10.7",
+    "mkdocs-redirects>=1.2.1",
+    "mkdocs-embed-external-markdown>=3.0.2",
+    "mkdocs-exclude>=1.0.2",
+    "mkdocs-material[imaging]>=9.5.31",
+    "mkdocs-simple-hooks>=0.1.5",
+    "mkdocs-snippets>=0.1.0"
+]
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.11.0"


### PR DESCRIPTION
For easier contributions to docs, this PR adds the optional docs dependencies in `pyproject.toml` (for those not using `poetry`)