### PR TITLE
fix: update registry doc

### DIFF
--- a/docs/agents/registry.md
+++ b/docs/agents/registry.md
@@ -1,26 +1,29 @@
-# Registry (NEAR AI Hub): Finding and Publishing Agents
+# Agent Registry: Finding and Publishing Agents
 
-NEAR AI agents can be deployed and hosted in a common registry, allowing the community to share their creations. This is also refered to as the **NEAR AI Hub**.
+NEAR AI agents can be deployed and hosted in a common registry, allowing the community to share their creations. This registry is used by the [NEAR AI Developer Hub](https://app.near.ai/agents) to store and serve agents.
 
 Let's take a look at how we can navigate this registry, download agents, and contribute our own agents to the ecosystem.
 
 !!! note
-    NEAR AI Hub is backed by an S3 bucket with metadata stored in a database.
+    The agent registry is backed by an S3 bucket with metadata stored in a database.
 
 ---
 
 ## Finding an Agent
 
-There are two main ways to navigate the Hub to find agents: 
+There are two main ways to navigate the agent registry to discover agents: 
 
-- Online via [app.near.ai/agents](https://app.near.ai/agents)
-- Using [NEAR AI CLI](./quickstart.md):
+- [NEAR AI Developer Hub](https://app.near.ai/agents)
+- [NEAR AI CLI](./quickstart.md)
 
-For the rest of this guide, we will use the CLI to find and deploy agents.
+For the rest of this guide, we will use the CLI to find and deploy agents. 
+
+!!! tip
+    Refer to the [Quickstart Guide](./quickstart.md) to learn how to install the CLI and login to the AI Developer Hub.
 
 ### View all agents
 
-To view all agents with `nearai` CLI command, run:
+To view all agents with `nearai` CLI, run:
 
 ```bash
 nearai registry list --category agent
@@ -42,19 +45,16 @@ nearai registry list --category agent
     └─────────────────────────────────┴─────────────────────────┴───────┘
     ```
 
-!!! tip
-    You can run deploy and run agents **directly on the [app.near.ai](https://app.near.ai/agents)** to see how they work
-
 <hr class="subsection" />
 
 ### Filtering Agents
 
-You can further filter the agents in two ways:
+You can further filter the agents with two flags:
 
-- By the developer that created it -> `--namespace`
-- By the tags  that were added to it -> `--tags`
+- `--namespace` : The developer that created it
+- `--tags`: Any tags that were added to the agent
 
-For example, to find all agents created by `gagdiez.near` with the tag `template`, you can run:
+For example, to find all agents created by `gagdiez.near` with the tag `template`, run:
 
 ```bash
 nearai registry list  --category agent \
@@ -74,20 +74,24 @@ nearai registry list  --category agent \
 
 ## Downloading an Agent
 
-Once you find an agent that you would like to download, you can use the `download` command to pull it down to your local machine. The command expects an agent of the form:
+Once you find an agent that you would like to download, use the `download` command to save it locally. Agent details are passed in the following format:
 
 ```bash
 nearai registry download <account.near>/<agent_name>/<version>
 ```
 
-Where version can be a specific version number, or `latest` to download the most recent version, for example: 
+The `version` can be a specific version number, or `latest` to download the most recent version.
+
+ Example: 
 
 ```bash 
 # Download a hello world agent
 nearai registry download gagdiez.near/hello-ai/latest
 ```
 
-By default, the agent will be **downloaded to the `~/.nearai/registry` local directory**, for example the agent above will be downloaded to `~/.nearai/registry/gagdiez.near/hello-ai/latest`.
+This command saves the agent locally in `.nearai/registry` under your home directory.
+
+The example above would save to: `~/.nearai/registry/gagdiez.near/hello-ai/latest`.
 
 !!! tip
     The `--force` flag allows you to overwrite the local agent with the version from the registry.
@@ -96,15 +100,18 @@ By default, the agent will be **downloaded to the `~/.nearai/registry` local dir
 
 ## Uploading an Agent
 
-If you created an agent and would like to share it with others, you can upload it to the registry. To upload an agent, you must have a [**logged in**](./quickstart.md#login-to-near-ai).
+If you created an agent and would like to share it with others, you can upload it to the registry. To upload an agent, you must be [**logged in**](./quickstart.md#login-to-near-ai).
 
-The `upload` command expects the path to the agent's local directory, for example:
+The `upload` command requires the path to the agent folder stored locally, for example:
 
 ```bash
 nearai registry upload ~/.nearai/registry/<your-account.near>/<agent_folder>
 ```
 
-The folder must contain an `agent.py` file, where the agent's logic is written, and a `metadata.json` file that holds information such as a description, tags, and the model used by the agent.
+The folder must contain:
+
+- `agent.py`: Agent logic
+- `metadata.json`: Agent information _(ex: description, tags, and model, etc.)_
 
 ??? note "Example `metadata.json` file"
 
@@ -137,11 +144,7 @@ The folder must contain an `agent.py` file, where the agent's logic is written, 
     ```
 
 !!! danger
-    **All files** in this folder **will be uploaded** to the registry! Make sure you are not including any sensitive data
+    **All files** in this folder **will be uploaded** to the registry which is **PUBLIC!** Make sure you are not including any sensitive data.
 
 !!! warning
     You can't remove or overwrite a file once it's uploaded, but you can hide the entire agent by setting the `"show_entry": false` field in the `metadata.json` file
-
-## Find agents from the agent
-
-* [`find_agents`](../api.md#nearai.agents.environment.Environment.find_agents): Find agents based on various parameters.

--- a/docs/agents/registry.md
+++ b/docs/agents/registry.md
@@ -1,21 +1,28 @@
-# The Registry: Finding and Publishing Agents
+# Registry (NEAR AI Hub): Finding and Publishing Agents
 
-NEAR AI agents can be stored in a common registry, allowing the community to share their creations.
+NEAR AI agents can be deployed and hosted in a common registry, allowing the community to share their creations. This is also refered to as the **NEAR AI Hub**.
 
-Let's take a look at how we can navigate the registry, download agents, and contribute our own agents to the ecosystem.
+Let's take a look at how we can navigate this registry, download agents, and contribute our own agents to the ecosystem.
 
 !!! note
-    The registry is backed by an S3 bucket with metadata stored in a database.
+    NEAR AI Hub is backed by an S3 bucket with metadata stored in a database.
 
 ---
 
 ## Finding an Agent
 
-There are two main ways to navigate the registry to find agents: through the [Web AI Hub](https://app.near.ai/agents), or using the [NEAR AI CLI](./quickstart.md):
+There are two main ways to navigate the Hub to find agents: 
 
+- Online via [app.near.ai/agents](https://app.near.ai/agents)
+- Using [NEAR AI CLI](./quickstart.md):
+
+For the rest of this guide, we will use the CLI to find and deploy agents.
+
+### View all agents
+
+To view all agents with `nearai` CLI command, run:
 
 ```bash
-# List all agents
 nearai registry list --category agent
 ```
 
@@ -36,12 +43,16 @@ nearai registry list --category agent
     ```
 
 !!! tip
-    You can run the agents **directly on the [Web AI Hub](https://app.near.ai/agents)** to see how they work
+    You can run deploy and run agents **directly on the [app.near.ai](https://app.near.ai/agents)** to see how they work
 
 <hr class="subsection" />
 
 ### Filtering Agents
-You can further filter the agents by the developer that created it (`--namespace`) or the tags (`--tags`) that were added to it.
+
+You can further filter the agents in two ways:
+
+- By the developer that created it -> `--namespace`
+- By the tags  that were added to it -> `--tags`
 
 For example, to find all agents created by `gagdiez.near` with the tag `template`, you can run:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,11 +34,11 @@ Driven by one of the minds behinds **TensorFlow** and the **Transformer Architec
     </span>
 
 
--   :material-web: __Web Hub__ :octicons-link-external-16:
+-   :material-web: __NEAR AI Hub__ :octicons-link-external-16:
 
     ---
 
-    Use our Web Hub to discover agents, datasets, and models with ease
+    Use our public AI hub to discover and deploy agents, datasets, and models with ease. 
 
     <span style="display: flex; justify-content: space-between;">
     [:material-robot-happy: Agents](https://app.near.ai/agents)

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Driven by one of the minds behinds **TensorFlow** and the **Transformer Architec
 
     ---
 
-    An AI developer hub to discover and deploy agents, datasets, and models with ease. 
+    NEAR AI developer hub where you can discover and deploy agents, datasets, and models with ease. 
 
     <span style="display: flex; justify-content: space-between;">
     [:material-robot-happy: Agents](https://app.near.ai/agents)

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,11 +34,11 @@ Driven by one of the minds behinds **TensorFlow** and the **Transformer Architec
     </span>
 
 
--   :material-web: __NEAR AI Hub__ :octicons-link-external-16:
+-   :material-web: __Developer Hub__ :octicons-link-external-16:
 
     ---
 
-    Use our public AI hub to discover and deploy agents, datasets, and models with ease. 
+    An AI developer hub to discover and deploy agents, datasets, and models with ease. 
 
     <span style="display: flex; justify-content: space-between;">
     [:material-robot-happy: Agents](https://app.near.ai/agents)

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -136,7 +136,7 @@ nav:
     - Private & Verifiable AI: 'private-ml-sdk.md'
   - Agents:
     - Quickstart: 'agents/quickstart.md'
-    - Registry (NEAR AI Hub): 'agents/registry.md'
+    - Agent Registry: 'agents/registry.md'
     - Local & Remote Runs: 'agents/running.md'
     - Threads: 'agents/threads.md'
     - Environment:

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -136,7 +136,7 @@ nav:
     - Private & Verifiable AI: 'private-ml-sdk.md'
   - Agents:
     - Quickstart: 'agents/quickstart.md'
-    - Registry: 'agents/registry.md'
+    - Registry (NEAR AI Hub): 'agents/registry.md'
     - Local & Remote Runs: 'agents/running.md'
     - Threads: 'agents/threads.md'
     - Environment:


### PR DESCRIPTION
To further clarify what the registry is and what the HUB is, this PR explains the relationship between the two. 

- Registry -> Agent Registry (more clarity)
- Explains that the registry is used to store and serve agents on the AI Developer Hub
- Web Hub -> Developer Hub (per @ewiner)
- General improvements to `registry.md`