### PR TITLE
feat: add docs PR preview

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,41 @@
+# .github/workflows/preview.yml
+name: Deploy PR previews
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        if: github.event.action != 'closed'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        if: github.event.action != 'closed'
+        run: |
+          pip install mkdocs mkdocs-material mkdocs-autorefs mkdocs-minify-plugin "mkdocstrings[python]" "mkdocs-material[imaging]"
+
+      - name: Build documentation
+        if: github.event.action != 'closed'
+        run: mkdocs build
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./site/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -8,6 +8,9 @@ on:
       - reopened
       - synchronize
       - closed
+    paths:
+      - 'mkdocs.yaml'
+      - 'docs/**'
 
 concurrency: preview-${{ github.ref }}
 


### PR DESCRIPTION
Adds PR preview ONLY when making changes to docs
- Creates and deploys previews of pull requests to a GH pages preview site
- Leaves a comment on the pull request with a link to the preview for faster review/collaboration
- Updates the deployment and the comment whenever new commits are pushed to the pull request
- Cleans up after itself — removes deployed previews when the pull request is closed
- Can be configured to override any of these features

[See official docs for more info ](https://github.com/marketplace/actions/deploy-pr-preview)
