### PR TITLE
chore: adding ic-py dependency to base framework to interact with ICP

### DIFF
--- a/aws_runner/frameworks/requirements-base.txt
+++ b/aws_runner/frameworks/requirements-base.txt
@@ -16,3 +16,4 @@ ed25519 == 1.5
 tweepy >= 4.14.0
 tenacity == 9.0.0
 mcp
+ic-py


### PR DESCRIPTION
- Adding ic-py to the base framework to support interacting with ICP. 
- ic-py is the python client for ICP. 

PS: Although the client is not maintained and last commit was in 2022, it is the only client available at the moment for ICP. 