### PR TITLE
Fix env.completions_and_run_tools

### DIFF
--- a/nearai/agents/environment.py
+++ b/nearai/agents/environment.py
@@ -1209,7 +1209,8 @@ class Environment(object):
     ) -> Tuple[Optional[str], Optional[List[ChatCompletionMessageToolCall]]]:
         if hasattr(response_message, "tool_calls") and response_message.tool_calls:
             return response_message.content, response_message.tool_calls
-        if "content" not in response_message or response_message.content is None:
+        content = response_message.content
+        if content is None:
             return None, None
         content = response_message.content
         llama_matches = LLAMA_TOOL_FORMAT_PATTERN.findall(content)


### PR DESCRIPTION
Agent:

```
from nearai.agents.environment import Environment
def run(env: Environment):
    tool_registry = env.get_tool_registry(new=True)
    prompt = {"role": "system", "content": "You are assistant."}
    response = env.completions_and_run_tools([prompt] + env.list_messages(), tools=tool_registry.get_all_tool_definitions())
run(env)
```

This is a revert of a change in here: https://github.com/nearai/nearai/pull/854/files#diff-d7c24ad303831791e888769f5c7d9613326fe1119e10d85dc1239405a232764b