### PR TITLE
feat: add `mkdocs-redirect` plugin

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -177,3 +177,6 @@ plugins:
             allow_inspection: true
             show_bases: true
             show_submodules: true
+  - redirects:
+      redirect_maps:
+        'agents/secrets.md': 'agents/env/variables.md'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ docs = [
     "mkdocs-exclude>=1.0.2",
     "mkdocs-material[imaging]>=9.5.31",
     "mkdocs-simple-hooks>=0.1.5",
+    "mkdocs-redirects>=1.2.1",
 ]
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
- Adds `mkdocs-redirect` plugin for easy documentation redirects
- Redirects `/agents/secrets/` to `agent/env/variables`  due to merger 
  - https://github.com/nearai/nearai/pull/879