### PR TITLE
Enhanced Unicode Handling

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2117,6 +2117,22 @@ test-full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "cloudpickle", "dask", "d
 tqdm = ["tqdm"]
 
 [[package]]
+name = "ftfy"
+version = "6.3.1"
+description = "Fixes mojibake and other problems with Unicode, after the fact"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version <= \"3.11\""
+files = [
+    {file = "ftfy-6.3.1-py3-none-any.whl", hash = "sha256:7c70eb532015cd2f9adb53f101fb6c7945988d023a085d127d1573dc49dd0083"},
+    {file = "ftfy-6.3.1.tar.gz", hash = "sha256:9b3c3d90f84fb267fe64d375a07b7f8912d817cf86009ae134aa03e1819506ec"},
+]
+
+[package.dependencies]
+wcwidth = "*"
+
+[[package]]
 name = "gguf"
 version = "0.9.1"
 description = "Read and write ML models in GGUF for GGML"
@@ -8712,7 +8728,7 @@ version = "0.2.13"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "python_version <= \"3.11\""
 files = [
     {file = "wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859"},
@@ -9329,4 +9345,4 @@ vllm = ["torch", "vllm"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.12"
-content-hash = "5d9244794520309cb9ed8bd83a517af4e767962931b74f77cab81aacf2c93f02"
+content-hash = "330e7306390ddd5569ba5e8bf04131bbf3127a98c4254d60873d7151999698ce"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
     "poetry (>=2.0.1,<3.0.0)",
     "py-near>=1.1.50,<2.0.0",
     "loguru>=0.7.2,<0.8.0",
+    "ftfy>=6.3.1"
 ]
 
 [tool.poetry.dependencies]
@@ -121,6 +122,7 @@ tweepy = { version = "^4.14.0" }
 rich = "^13.7.0"
 py-near = "^1.1.50"
 loguru = "^0.7.2"
+ftfy = "^6.3.1"
 
 [project.optional-dependencies]
 # Experiment platform


### PR DESCRIPTION
fix: recursive sanitize() function to clean metadata inputs
feat: automatic preprocessing for all metadata inputs
fix: replaced default JSON type with custom UnicodeSafeJSON everywhere. UnicodeSafeJSON before was used for messages.content only.
feat: explicit table settings for registry items
feat: tag normalization: deduplication, whitespace trimming, case folding

This kind of metadata processed without issues after this PR
```
{
  "category": "agent",
  "description": "tweak or enhance the agentâ€™s functionality? í ½íº€",
  "tags": ["â€“test", "яблоко", "яблоко", "❤️"],
  "details": {
    "key": "valueâ€™",
    "agent": {
      "welcome": {
        "description": "\\\\ud83d\\\\ude0a",
        "title": "Агент í ½íº€"
      }
    },
  },
  "show_entry": true,
  "name": "hacker-agent",
  "version": "0.11"
}
```
![Screenshot 2025-02-21 at 10 39 08 PM](https://github.com/user-attachments/assets/e23a0870-55d4-485a-be39-47a454034aec)

