### PR TITLE
Improve welcome message UI

### DIFF
--- a/hub/demo/package-lock.json
+++ b/hub/demo/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@gera2ld/tarjs": "^0.3.1",
         "@hookform/resolvers": "^3.6.0",
-        "@near-pagoda/ui": "^3.1.9",
+        "@near-pagoda/ui": "^3.1.10",
         "@near-wallet-selector/bitte-wallet": "8.9.14",
         "@near-wallet-selector/core": "8.9.14",
         "@near-wallet-selector/here-wallet": "8.9.14",
@@ -2801,9 +2801,9 @@
       }
     },
     "node_modules/@near-pagoda/ui": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@near-pagoda/ui/-/ui-3.1.9.tgz",
-      "integrity": "sha512-fvpn6qj8Tcf/SG5tf1nYk4VldFFa3tqZNry3uPTRNwNZTWZvnfaADRZDaclWjswPwj0D91L919RbmPDx0dNWiQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@near-pagoda/ui/-/ui-3.1.10.tgz",
+      "integrity": "sha512-g+3OXGKvRu2VTOpscGzTBLUyZ+ddg9/QUob6MT8AxcBUXgsJS+Lz0a1Im9fSTjScmT3Tl+roJbR+HczBOBa+Zg==",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.5",
         "@radix-ui/colors": "^3.0.0",
@@ -8322,21 +8322,17 @@
       ]
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.1.tgz",
-      "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^1.1.1"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -11534,9 +11530,9 @@
       }
     },
     "node_modules/parse-path": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
-      "integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.1.tgz",
+      "integrity": "sha512-6ReLMptznuuOEzLoGEa+I1oWRSj2Zna5jLWC+l6zlfAI4dbbSaIES29ThzuPkbhNahT65dWzfoZEO6cfJw2Ksg==",
       "dependencies": {
         "protocols": "^2.0.0"
       }
@@ -11753,9 +11749,9 @@
       }
     },
     "node_modules/protocols": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
-      "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
+      "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -12275,9 +12271,9 @@
       }
     },
     "node_modules/repomix": {
-      "version": "0.2.26",
-      "resolved": "https://registry.npmjs.org/repomix/-/repomix-0.2.26.tgz",
-      "integrity": "sha512-wVpDVphK0wKFb3KVkrbwLs45dJlV8cMopNqmeTzEyZivNXVRHuPrtF2RgE/BMlXFxArnE43JhqDpYRINFdaHCA==",
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/repomix/-/repomix-0.2.29.tgz",
+      "integrity": "sha512-WWQEt6mGPYCkgu737ldhOFtCldbPTnlapqVu3xwRiX9KLpuIz2cRZLIsA5M1wMpV83vfPxtas/TZum6S/H36wA==",
       "dependencies": {
         "@clack/prompts": "^0.9.1",
         "@secretlint/core": "^9.0.0",
@@ -12299,6 +12295,8 @@
         "strip-comments": "^2.0.1",
         "strip-json-comments": "^5.0.1",
         "tiktoken": "^1.0.19",
+        "tree-sitter-wasms": "^0.1.12",
+        "web-tree-sitter": "^0.24.7",
         "zod": "^3.24.1"
       },
       "bin": {
@@ -13153,9 +13151,15 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.1.tgz",
+      "integrity": "sha512-O7aCHfYCamLCctjAiaucmE+fHf2DYHkus2OKCn4Wv03sykfFtgeECn505X6K4mPl8CRNd/qurC9guq+ynoN4pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
     },
     "node_modules/structured-source": {
       "version": "4.0.0",
@@ -13348,6 +13352,14 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/tree-sitter-wasms": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/tree-sitter-wasms/-/tree-sitter-wasms-0.1.12.tgz",
+      "integrity": "sha512-N9Jp+dkB23Ul5Gw0utm+3pvG4km4Fxsi2jmtMFg7ivzwqWPlSyrYQIrOmcX+79taVfcHEA+NzP0hl7vXL8DNUQ==",
+      "dependencies": {
+        "tree-sitter-wasms": "^0.1.11"
+      }
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -13805,6 +13817,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/web-tree-sitter": {
+      "version": "0.24.7",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.7.tgz",
+      "integrity": "sha512-CdC/TqVFbXqR+C51v38hv6wOPatKEUGxa39scAeFSm98wIhZxAYonhRQPSMmfZ2w7JDI0zQDdzdmgtNk06/krQ=="
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/hub/demo/package.json
+++ b/hub/demo/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@gera2ld/tarjs": "^0.3.1",
     "@hookform/resolvers": "^3.6.0",
-    "@near-pagoda/ui": "^3.1.9",
+    "@near-pagoda/ui": "^3.1.10",
     "@near-wallet-selector/bitte-wallet": "8.9.14",
     "@near-wallet-selector/core": "8.9.14",
     "@near-wallet-selector/here-wallet": "8.9.14",

--- a/hub/demo/src/components/AgentRunner.tsx
+++ b/hub/demo/src/components/AgentRunner.tsx
@@ -451,9 +451,7 @@ export const AgentRunner = ({
                 <ThreadMessages
                   messages={messages}
                   threadId={threadId}
-                  welcomeMessage={
-                    <AgentWelcome details={currentEntry.details} />
-                  }
+                  welcomeMessage={<AgentWelcome currentEntry={currentEntry} />}
                 />
               )}
             </>

--- a/hub/demo/src/components/AgentWelcome.tsx
+++ b/hub/demo/src/components/AgentWelcome.tsx
@@ -1,37 +1,56 @@
 'use client';
 
-import { Container, Flex, Text } from '@near-pagoda/ui';
+import { Flex, ImageIcon, Text } from '@near-pagoda/ui';
 import { type z } from 'zod';
 
+import { ENTRY_CATEGORY_LABELS } from '~/lib/entries';
 import { type entryModel } from '~/lib/models';
 
 import { Markdown } from './lib/Markdown';
 
 type Props = {
-  details: z.infer<typeof entryModel>['details'];
+  currentEntry: z.infer<typeof entryModel>;
 };
 
-export const AgentWelcome = ({ details }: Props) => {
-  const welcome = details.agent?.welcome;
+export const AgentWelcome = ({ currentEntry }: Props) => {
+  const welcome = currentEntry.details.agent?.welcome;
 
-  if (!welcome?.title || !welcome?.description) return null;
+  if (!welcome) return null;
 
   return (
-    <Container size="s" style={{ margin: 'auto' }}>
-      <Flex
-        direction="column"
-        gap="m"
-        style={{
-          borderImageSource:
-            'linear-gradient(to bottom, var(--green-9), var(--violet-9))',
-          borderImageSlice: 1,
-          borderLeft: '2px solid',
-          paddingLeft: 'var(--gap-l)',
-        }}
-      >
-        {welcome.title && <Text size="text-l">{welcome.title}</Text>}
-        <Markdown content={`How can I help you today?`} />
+    <Flex
+      direction="column"
+      gap="m"
+      style={{
+        marginTop: 'auto',
+      }}
+    >
+      <Flex align="center" gap="m">
+        <ImageIcon
+          size="l"
+          src={welcome.icon || currentEntry.details.icon}
+          alt={currentEntry.name}
+          fallbackIcon={ENTRY_CATEGORY_LABELS.agent.icon}
+        />
+        <Text size="text-l">{welcome.title || currentEntry.name}</Text>
       </Flex>
-    </Container>
+
+      {welcome.description && (
+        <Flex
+          direction="column"
+          gap="m"
+          style={{
+            borderImageSource:
+              'linear-gradient(to bottom, var(--green-9), var(--violet-9))',
+            borderImageSlice: 1,
+            borderLeft: '2px solid',
+            paddingLeft: 'calc((var(--icon-size-l) / 2) + var(--gap-m))',
+            marginLeft: 'calc(var(--icon-size-l) / 2)',
+          }}
+        >
+          <Markdown content={welcome.description} />
+        </Flex>
+      )}
+    </Flex>
   );
 };

--- a/hub/demo/src/components/EntryDetailsLayout.tsx
+++ b/hub/demo/src/components/EntryDetailsLayout.tsx
@@ -48,6 +48,8 @@ type Props = {
     | null;
 };
 
+export const ENTRY_DETAILS_LAYOUT_SIZE_NAME = 'entry-details-layout';
+
 export const EntryDetailsLayout = ({
   category,
   children,

--- a/hub/demo/src/components/lib/Sidebar/Sidebar.module.scss
+++ b/hub/demo/src/components/lib/Sidebar/Sidebar.module.scss
@@ -50,7 +50,7 @@
   z-index: 250;
   top: var(--header-height);
   max-width: 100%;
-  max-height: var(--section-fill-height);
+  max-height: calc(100svh - max(var(--header-height), var(--sidebar-root-top)));
   min-height: 0;
   flex-shrink: 0;
   box-shadow: 0 0 1rem rgba(0, 0, 0, 0.1);

--- a/hub/demo/src/components/lib/Sidebar/Sidebar.tsx
+++ b/hub/demo/src/components/lib/Sidebar/Sidebar.tsx
@@ -2,14 +2,41 @@
 
 import { Button } from '@near-pagoda/ui';
 import { X } from '@phosphor-icons/react';
-import { type CSSProperties, type ReactNode } from 'react';
+import { type CSSProperties, type ReactNode, useEffect, useRef } from 'react';
 
 import { Footer } from '~/components/Footer';
 
 import s from './Sidebar.module.scss';
 
 export const Root = (props: { children: ReactNode }) => {
-  return <div className={s.root} {...props} />;
+  const elementRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element) return;
+
+    function calculateSize() {
+      if (!element) return;
+      const rect = element.getBoundingClientRect();
+      const top = Math.max(0, rect.top);
+      element.style.setProperty(`--sidebar-root-top`, `${top}px`);
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      calculateSize();
+    });
+
+    calculateSize();
+    resizeObserver.observe(element);
+    window.addEventListener('scroll', calculateSize);
+
+    () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('scroll', calculateSize);
+    };
+  }, []);
+
+  return <div className={s.root} ref={elementRef} {...props} />;
 };
 
 export const Main = ({

--- a/hub/demo/src/lib/models.ts
+++ b/hub/demo/src/lib/models.ts
@@ -93,6 +93,7 @@ export const entryDetailsModel = z.intersection(
             .object({
               title: z.string(),
               description: z.string(),
+              icon: z.string(),
             })
             .partial(),
         })


### PR DESCRIPTION
- Fixed accidental hardcoding of `welcome.description`
- Add ability to provide custom `welcome.icon` to override root `icon`. The icon will now render as part of the welcome message next to the title.
- Improved welcome layout to draw user focus to bottom of screen where interactions will occur
- This layout will also work better if the `welcome.description` happens to contain a good chunk of markdown content
- Improved sidebar height scroll handling for certain edge cases that were bothering my OCD based on your screen height and how many threads you had in your sidebar. The main screen shouldn't have a scrollbar until the thread message contents actually starts to grow past the screen size.

New layout:

<img width="1015" alt="Screenshot 2025-02-21 at 3 45 58 PM" src="https://github.com/user-attachments/assets/d8504899-d2a4-4cbd-9828-6084fd3606bf" />

Old/current layout:

<img width="1039" alt="Screenshot 2025-02-21 at 3 52 36 PM" src="https://github.com/user-attachments/assets/ef6769a9-987c-4935-b879-f3cbe47dda27" />
