### PR TITLE
Allow agents to be embedded as an iframe

### DIFF
--- a/hub/demo/src/app/embed/[namespace]/[name]/[version]/page.tsx
+++ b/hub/demo/src/app/embed/[namespace]/[name]/[version]/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { AgentRunner } from '~/components/AgentRunner';
+import { useEntryParams } from '~/hooks/entries';
+import { useQueryParams } from '~/hooks/url';
+import { SIGN_IN_CALLBACK_PATH, SIGN_IN_RESTORE_URL_KEY } from '~/lib/auth';
+
+export default function EmbedAgentPage() {
+  const router = useRouter();
+  const { namespace, name, version } = useEntryParams();
+  const { queryParams } = useQueryParams([
+    'showThreads',
+    'showOutputAndEnvVars',
+  ]);
+  const showThreads = queryParams.showThreads === 'true';
+  const showOutputAndEnvVars = queryParams.showOutputAndEnvVars === 'true';
+
+  useEffect(() => {
+    if (location.hash) {
+      localStorage.setItem(
+        SIGN_IN_RESTORE_URL_KEY,
+        `${location.pathname}${location.search}`,
+      );
+      router.replace(SIGN_IN_CALLBACK_PATH + location.hash);
+    }
+  }, [router]);
+
+  return (
+    <AgentRunner
+      namespace={namespace}
+      name={name}
+      version={version}
+      showLoadingPlaceholder={true}
+      showThreads={showThreads}
+      showOutputAndEnvVars={showOutputAndEnvVars}
+    />
+  );
+}

--- a/hub/demo/src/app/sign-in/callback/page.tsx
+++ b/hub/demo/src/app/sign-in/callback/page.tsx
@@ -13,6 +13,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { type z } from 'zod';
 
+import { useIsEmbeddedIframe } from '~/hooks/embed';
 import {
   extractSignatureFromHashParams,
   MESSAGE,
@@ -33,12 +34,12 @@ export default function SignInCallbackPage() {
     typeof authorizationModel
   > | null>(null);
   const [isInvalidToken, setIsInvalidToken] = useState(false);
+  const { isEmbedded } = useIsEmbeddedIframe();
 
   useEffect(() => {
     async function parseToken() {
       try {
         const hashParams = extractSignatureFromHashParams();
-        const nonce = returnSignInNonce();
 
         const auth = authorizationModel.parse({
           account_id: hashParams?.accountId,
@@ -47,7 +48,7 @@ export default function SignInCallbackPage() {
           callback_url: returnSignInCallbackUrl(),
           message: MESSAGE,
           recipient: RECIPIENT,
-          nonce,
+          nonce: hashParams?.nonce || returnSignInNonce(),
         });
 
         setParsedAuth(auth);
@@ -88,12 +89,14 @@ export default function SignInCallbackPage() {
                 Your token is invalid. Please try signing in again.
               </Text>
 
-              <Button
-                variant="affirmative"
-                label="Sign In"
-                onClick={() => signInWithNear()}
-                iconRight={<ArrowRight />}
-              />
+              {!isEmbedded && (
+                <Button
+                  variant="affirmative"
+                  label="Sign In"
+                  onClick={() => signInWithNear()}
+                  iconRight={<ArrowRight />}
+                />
+              )}
             </>
           ) : (
             <>

--- a/hub/demo/src/components/Footer.tsx
+++ b/hub/demo/src/components/Footer.tsx
@@ -30,6 +30,7 @@ export const Footer = ({ conditional }: Props) => {
   useEffect(() => {
     setMounted(true);
   }, []);
+
   return (
     <footer
       className={s.footer}

--- a/hub/demo/src/components/Navigation.tsx
+++ b/hub/demo/src/components/Navigation.tsx
@@ -34,6 +34,7 @@ import { useEffect, useState } from 'react';
 
 import { APP_TITLE } from '~/constants';
 import { env } from '~/env';
+import { useIsEmbeddedIframe } from '~/hooks/embed';
 import { signInWithNear } from '~/lib/auth';
 import { ENTRY_CATEGORY_LABELS } from '~/lib/entries';
 import { useAuthStore } from '~/stores/auth';
@@ -118,10 +119,18 @@ export const Navigation = () => {
   const path = usePathname();
   const [mounted, setMounted] = useState(false);
   const { resolvedTheme, setTheme } = useTheme();
+  const { isEmbedded } = useIsEmbeddedIframe();
 
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  useEffect(() => {
+    if (isEmbedded) {
+      document.body.style.setProperty('--header-height', '0px');
+      document.body.style.setProperty('--section-fill-height', '100svh');
+    }
+  }, [isEmbedded]);
 
   const signOut = () => {
     void clearTokenMutation.mutate();
@@ -136,6 +145,8 @@ export const Navigation = () => {
       void wallet.signOut();
     }
   };
+
+  if (isEmbedded) return null;
 
   return (
     <header className={s.navigation}>

--- a/hub/demo/src/components/SignInPrompt.tsx
+++ b/hub/demo/src/components/SignInPrompt.tsx
@@ -3,6 +3,7 @@
 import { Button, Container, Flex, Section, Text } from '@near-pagoda/ui';
 import { ArrowRight } from '@phosphor-icons/react';
 
+import { useIsEmbeddedIframe } from '~/hooks/embed';
 import { signInWithNear } from '~/lib/auth';
 
 type Props = {
@@ -10,40 +11,46 @@ type Props = {
 };
 
 export const SignInPrompt = ({ layout = 'horizontal-right' }: Props) => {
+  const { isEmbedded } = useIsEmbeddedIframe();
+
   return (
     <Flex
       gap="m"
       align="center"
       justify={layout === 'horizontal-right' ? 'end' : 'space-between'}
     >
-      <Text size="text-s">
-        Please sign in with your NEAR wallet to continue
-      </Text>
-      <Button
-        variant="affirmative"
-        label="Sign In"
-        onClick={signInWithNear}
-        size="small"
-        iconRight={<ArrowRight />}
-      />
+      <Text size="text-s">Please sign in to continue</Text>
+      {!isEmbedded && (
+        <Button
+          variant="affirmative"
+          label="Sign In"
+          onClick={signInWithNear}
+          size="small"
+          iconRight={<ArrowRight />}
+        />
+      )}
     </Flex>
   );
 };
 
 export const SignInPromptSection = () => {
+  const { isEmbedded } = useIsEmbeddedIframe();
+
   return (
     <Section grow="available">
       <Container size="s" style={{ margin: 'auto', textAlign: 'center' }}>
         <Flex direction="column" gap="m" align="center">
           <Text size="text-l">Welcome</Text>
-          <Text>Please sign in with your NEAR wallet to continue</Text>
-          <Button
-            variant="affirmative"
-            label="Sign In"
-            onClick={signInWithNear}
-            size="large"
-            iconRight={<ArrowRight />}
-          />
+          <Text>Please sign in to continue</Text>
+          {!isEmbedded && (
+            <Button
+              variant="affirmative"
+              label="Sign In"
+              onClick={signInWithNear}
+              size="large"
+              iconRight={<ArrowRight />}
+            />
+          )}
         </Flex>
       </Container>
     </Section>

--- a/hub/demo/src/hooks/embed.ts
+++ b/hub/demo/src/hooks/embed.ts
@@ -1,0 +1,17 @@
+import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+export function useIsEmbeddedIframe() {
+  const path = usePathname();
+  const [isEmbedded, setIsEmbedded] = useState(false);
+
+  useEffect(() => {
+    if (path.startsWith('/embed/')) {
+      document.body.style.setProperty('--header-height', '0px');
+      document.body.style.setProperty('--section-fill-height', '100svh');
+      setIsEmbedded(true);
+    }
+  }, [path]);
+
+  return { isEmbedded };
+}

--- a/hub/demo/src/lib/auth.ts
+++ b/hub/demo/src/lib/auth.ts
@@ -8,7 +8,7 @@ export const MESSAGE = 'Welcome to NEAR AI Hub!';
 export const REVOKE_MESSAGE = 'Are you sure? Revoking a nonce';
 export const REVOKE_ALL_MESSAGE = 'Are you sure? Revoking all nonces';
 export const SIGN_IN_CALLBACK_PATH = '/sign-in/callback';
-const SIGN_IN_RESTORE_URL_KEY = 'signInRestoreUrl';
+export const SIGN_IN_RESTORE_URL_KEY = 'signInRestoreUrl';
 const SIGN_IN_NONCE_KEY = 'signInNonce';
 
 export function signInWithNear() {
@@ -94,6 +94,7 @@ export function extractSignatureFromHashParams() {
   const accountId = hashParams.accountId;
   const publicKey = hashParams.publicKey;
   const signature = hashParams.signature;
+  const nonce = hashParams.nonce;
 
-  return { accountId, publicKey, signature };
+  return { accountId, publicKey, signature, nonce };
 }


### PR DESCRIPTION
Closes: https://github.com/nearai/nearai/issues/931

- Introduce an `/embed/...` route that allows other developers to embed an agent on any website

Wallet sign in via `auth.near.ai` is not possible when embedded as an iframe due to security restrictions set by the wallet providers (which is a good thing).

The developer embedding the iframe will need to integrate with the `auth.near.ai` flow and pass the resulting `#` params as part of the iframe `src`. This will trigger our existing `/sign-in/callback` route to sign in with these URL parameters.

Example embed code:

```tsx
const hash

<iframe
  src="https://app.near.ai/embed/author.near/cool-agent/latest?showThreads=true&showOutputAndEnvVars=true#signature=foobar&accountId=foobar.near&publicKey=ed25519foobar&nonce=00000000000000000001740184404399"
  sandbox="allow-scripts allow-popups allow-same-origin allow-forms"
  style={{
    border: 'none',
    height: '600px',
  }}
/>
```

- `?showThreads=true/false` determines if the left sidebar of threads is shown
- `?showOutputAndEnvVars=true/false` determines if the right sidebar of file outputs and env vars is shown
- The `#` params at the end of the URL will be provided by `auth.near.ai` redirecting back to the developer's website after a successful sign in. This does not include `nonce` - the developer must provide this value to `auth.near.ai` and to the iframe `#` params.

Essentially the iframe `src` URL can be constructed roughly like so:

```js
const nonce = '00000000000000000001740184404399';
const src = `https://app.near.ai/embed/${namespace}/${name}/${version}${window.location.hash}&nonce=${nonce}`;
```