### PR TITLE
Add NEAR RPC proxy for client

### DIFF
--- a/hub/demo/next.config.js
+++ b/hub/demo/next.config.js
@@ -3,17 +3,21 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
-/**
- * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially useful
- * for Docker builds.
- */
-
-await import('./src/env.js');
+import { env } from './src/env.js';
 
 /** @type {import("next").NextConfig} */
 const config = {
   experimental: {
     missingSuspenseWithCSRBailout: false,
+  },
+
+  async rewrites() {
+    return [
+      {
+        source: '/api/near-rpc-proxy',
+        destination: env.NEAR_RPC_URL,
+      },
+    ];
   },
 
   webpack(config) {

--- a/hub/demo/src/env.js
+++ b/hub/demo/src/env.js
@@ -12,7 +12,7 @@ export const env = createEnv({
     ROUTER_URL: z.string().url(),
     DATA_SOURCE: z.enum(['registry', 'local_files']).default('registry'),
     AUTH_COOKIE_DOMAIN: z.string().optional(),
-    NEAR_RPC_URL: z.string().default('https://rpc.mainnet.near.org'),
+    NEAR_RPC_URL: z.string().url().default('https://rpc.mainnet.near.org'),
   },
 
   /**

--- a/hub/demo/src/env.js
+++ b/hub/demo/src/env.js
@@ -12,6 +12,7 @@ export const env = createEnv({
     ROUTER_URL: z.string().url(),
     DATA_SOURCE: z.enum(['registry', 'local_files']).default('registry'),
     AUTH_COOKIE_DOMAIN: z.string().optional(),
+    NEAR_RPC_URL: z.string().default('https://rpc.mainnet.near.org'),
   },
 
   /**
@@ -57,6 +58,7 @@ export const env = createEnv({
    */
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
+    NEAR_RPC_URL: process.env.NEAR_RPC_URL,
     ROUTER_URL: process.env.ROUTER_URL,
     NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_VERCEL_URL
       ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`

--- a/hub/demo/src/hooks/near.ts
+++ b/hub/demo/src/hooks/near.ts
@@ -20,7 +20,7 @@ export function useNearInitializer() {
         connectPromise.current = connect({
           networkId: 'mainnet',
           keyStore,
-          nodeUrl: 'https://rpc.mainnet.near.org',
+          nodeUrl: '/api/near-rpc-proxy',
         });
       }
 

--- a/hub/demo/src/hooks/wallet.ts
+++ b/hub/demo/src/hooks/wallet.ts
@@ -27,7 +27,11 @@ export function useWalletInitializer() {
     const initialize = async () => {
       if (!setupPromise.current) {
         setupPromise.current = setupWalletSelector({
-          network: 'mainnet',
+          // @ts-expect-error: Other url config values (helper, indexer) are not actually required
+          network: {
+            networkId: 'mainnet',
+            nodeUrl: '/api/near-rpc-proxy',
+          },
           modules: [
             setupMyNearWallet(),
             setupBitteWallet(),
@@ -35,7 +39,6 @@ export function useWalletInitializer() {
             setupSender(),
             setupHereWallet(),
           ],
-          fallbackRpcUrls: ['/api/near-rpc-proxy'],
         });
       }
 

--- a/hub/demo/src/hooks/wallet.ts
+++ b/hub/demo/src/hooks/wallet.ts
@@ -35,6 +35,7 @@ export function useWalletInitializer() {
             setupSender(),
             setupHereWallet(),
           ],
+          fallbackRpcUrls: ['/api/near-rpc-proxy'],
         });
       }
 


### PR DESCRIPTION
With these changes, our UI would call `/api/near-rpc-proxy` which will then be proxied to `NEAR_RPC_URL` - which defaults to `https://rpc.mainnet.near.org` 

@zavodil was running into an issue where his IP address might have been restricted or rate limited talking with the RPC. This proxy could potentially help. It would also allow us to easily swap to a different RPC provider like so:

```
NEAR_RPC_URL=https://rpc.mainnet.fastnear.com?apiKey=foobar
```

This has the drawback of potentially getting our entire app rate limited by whichever NEAR RPC provider we use. What would you suggest @ewiner? I know `https://rpc.mainnet.near.org` is being shutdown. Are we able to set up an account with FastNear that can handle the load we expect?

We noticed that wallet selector has a `fallbackRpcUrls` option, but it didn't seem to be working as expected: https://github.com/near/wallet-selector/pull/1153