### PR TITLE
This change is applied retroactively to align the migration file with…

### DIFF
--- a/hub/alembic/versions/fce1ee10b43d_create_table_registry_entry.py
+++ b/hub/alembic/versions/fce1ee10b43d_create_table_registry_entry.py
@@ -24,12 +24,14 @@ def upgrade() -> None:
         sa.Column("id", sa.Integer, primary_key=True),
         sa.Column("namespace", sa.String(255), nullable=False),
         sa.Column("name", sa.String(255), nullable=False),
-        sa.Column("version", sa.String(255), nullable=False),
+        sa.Column("version", sa.String(255, collation="utf8mb4_unicode_ci"), nullable=False),
         sa.Column("time", sa.DateTime, nullable=False),
-        sa.Column("description", sa.String(255), nullable=False),
         sa.Column("category", sa.String(255), nullable=False),
-        sa.Column("details", sa.JSON, nullable=True),
+        sa.Column("description", sa.String(255, collation="utf8mb4_unicode_ci"), nullable=False),
+        sa.Column("details", sa.Text(collation="utf8mb4_unicode_ci"), nullable=True),
         sa.Column("show_entry", sa.Boolean, nullable=False),
+        mysql_charset="utf8mb4",
+        mysql_collate="utf8mb4_unicode_ci",
     )
 
 


### PR DESCRIPTION
… the current production database state, where the column character sets and collations have already been manually updated as a hotfix.

The following changes are included:

Set utf8mb4_unicode_ci collation for all VARCHAR and TEXT columns (version, description, and details). Specify the default table character set and collation as utf8mb4 and utf8mb4_unicode_ci, respectively.

This approach ensures consistency for new installations while preserving the manually applied fixes on the production database.