### PR TITLE
fix: move docs agent to tutorial section

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,6 @@ Driven by one of the minds behinds **TensorFlow** and the **Transformer Architec
 
 ---
 
-<iframe src="https://app.near.ai/embed/gagdiez.near/docs-gpt/latest" class="agent-iframe" sandbox="allow-scripts allow-popups allow-same-origin allow-forms"></iframe>
-
 <div class="grid cards" markdown>
 
 -   :material-robot-happy: __NEAR AI Agents__

--- a/docs/tutorials/rag/agent.md
+++ b/docs/tutorials/rag/agent.md
@@ -1,7 +1,11 @@
 Let's see how simple it is to create an agent that leverages the vector store we [created in the previous section](./vector_store.md). This agent will demonstrate how to effectively use RAG (Retrieval-Augmented Generation) to provide accurate answers based on NEAR's documentation.
 
-!!! tip
-    Try out this code directly in the [NEAR AI platform](https://app.near.ai/agents/gagdiez.near/docs-gpt/latest/run)
+---
+
+!!!tip
+    You can try out a live demo of this agent by signing in with your NEAR account below!
+
+<iframe src="https://app.near.ai/embed/near-ai-dev.near/near-protocol-docs-agent/latest/" class="agent-iframe" sandbox="allow-scripts allow-popups allow-same-origin allow-forms"></iframe>
 
 ---
 


### PR DESCRIPTION
Relocate recently added docs AI agent to the relevant RAG tutorial section. NEAR AI docs agent coming soon :) 