### PR TITLE
Fix iframe embed logo in safari, add support for more embed options

### DIFF
--- a/docs/tutorials/rag/agent.md
+++ b/docs/tutorials/rag/agent.md
@@ -5,7 +5,7 @@ Let's see how simple it is to create an agent that leverages the vector store we
 !!!tip
     You can try out a live demo of this agent by signing in with your NEAR account below!
 
-<iframe src="https://app.near.ai/embed/near-ai-dev.near/near-protocol-docs-agent/latest/" class="agent-iframe" sandbox="allow-scripts allow-popups allow-same-origin allow-forms"></iframe>
+<iframe src="https://app.near.ai/embed/near-ai-dev.near/near-protocol-docs-agent/latest?theme=light" class="agent-iframe" sandbox="allow-scripts allow-popups allow-same-origin allow-forms"></iframe>
 
 ---
 

--- a/hub/demo/package-lock.json
+++ b/hub/demo/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@gera2ld/tarjs": "^0.3.1",
         "@hookform/resolvers": "^3.6.0",
-        "@near-pagoda/ui": "^3.2.1",
+        "@near-pagoda/ui": "^3.2.2",
         "@near-wallet-selector/bitte-wallet": "8.9.14",
         "@near-wallet-selector/core": "8.9.14",
         "@near-wallet-selector/here-wallet": "8.9.14",
@@ -2801,9 +2801,9 @@
       }
     },
     "node_modules/@near-pagoda/ui": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@near-pagoda/ui/-/ui-3.2.1.tgz",
-      "integrity": "sha512-mvbxdG60Pgpu2J3nHtZuLF3H9LgamfFkjHIUaAeen2nPzQSGmkgCg90zhiWHzbsBFizEn8xs6BGuc5zPAkzBLA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@near-pagoda/ui/-/ui-3.2.2.tgz",
+      "integrity": "sha512-MOx73uUEwL3dqEA+X9vI4ZH4TqRS+q4ZAnyjXApTuTyY6iCsaECki2ScN68Nu3+r6CuwRYiS2eH1Hq1QXv9g7A==",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.5",
         "@radix-ui/colors": "^3.0.0",

--- a/hub/demo/package.json
+++ b/hub/demo/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@gera2ld/tarjs": "^0.3.1",
     "@hookform/resolvers": "^3.6.0",
-    "@near-pagoda/ui": "^3.2.1",
+    "@near-pagoda/ui": "^3.2.2",
     "@near-wallet-selector/bitte-wallet": "8.9.14",
     "@near-wallet-selector/core": "8.9.14",
     "@near-wallet-selector/here-wallet": "8.9.14",

--- a/hub/demo/src/app/sign-in/callback/page.tsx
+++ b/hub/demo/src/app/sign-in/callback/page.tsx
@@ -8,7 +8,6 @@ import {
   Section,
   Text,
 } from '@near-pagoda/ui';
-import { ArrowRight } from '@phosphor-icons/react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { type z } from 'zod';
@@ -99,17 +98,12 @@ export default function SignInCallbackPage() {
                 Your token is invalid. Please try signing in again.
               </Text>
 
-              <Button
-                variant="affirmative"
-                label="Sign In"
-                onClick={() => signIn()}
-                iconRight={<ArrowRight />}
-              />
+              <Button label="Sign In" onClick={() => signIn()} />
             </>
           ) : (
             <>
               <Text color="sand-10">Verifying...</Text>
-              <Button icon={<></>} label="Sign In" loading fill="ghost" />
+              <Button label="Sign In" loading fill="ghost" />
             </>
           )}
         </Flex>

--- a/hub/demo/src/components/AgentRunner.tsx
+++ b/hub/demo/src/components/AgentRunner.tsx
@@ -80,17 +80,20 @@ export const AgentRunner = ({
   version,
   showLoadingPlaceholder,
 }: Props) => {
-  const { consumerModeEnabled } = useConsumerModeEnabled();
+  const { consumerModeEnabled, embedded } = useConsumerModeEnabled();
   const { currentEntry, currentEntryId: agentId } = useCurrentEntry('agent', {
-    namespace,
-    name,
-    version,
+    overrides: {
+      namespace,
+      name,
+      version,
+    },
   });
 
   const auth = useAuthStore((store) => store.auth);
   const { queryParams, updateQueryPath } = useQueryParams([
     'showLogs',
     'threadId',
+    'theme',
     'view',
     'initialUserMessage',
     'mockedAitpMessages',
@@ -571,7 +574,7 @@ export const AgentRunner = ({
                         />
                       </Tooltip>
 
-                      {consumerModeEnabled && (
+                      {consumerModeEnabled && !embedded && (
                         <Tooltip asChild content="Inspect agent source">
                           <Button
                             label="Agent Source"

--- a/hub/demo/src/components/EmbedAgentModal.tsx
+++ b/hub/demo/src/components/EmbedAgentModal.tsx
@@ -1,5 +1,13 @@
-import { Accordion, Dialog, Flex, SvgIcon, Text } from '@near-pagoda/ui';
+import {
+  Accordion,
+  Checkbox,
+  Dialog,
+  Flex,
+  SvgIcon,
+  Text,
+} from '@near-pagoda/ui';
 import { Code as CodeIcon } from '@phosphor-icons/react';
+import { useState } from 'react';
 import { type z } from 'zod';
 
 import { useCurrentEntryParams } from '~/hooks/entries';
@@ -17,6 +25,7 @@ type Props = {
 
 export const EmbedAgentModal = ({ entry, isOpen, setIsOpen }: Props) => {
   const { id } = useCurrentEntryParams();
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
 
   if (entry && entry.category !== 'agent') {
     throw new Error(
@@ -37,6 +46,35 @@ export const EmbedAgentModal = ({ entry, isOpen, setIsOpen }: Props) => {
                 </Text>
               </Flex>
 
+              <Flex direction="column" gap="s">
+                <Text size="text-xs" weight={600} uppercase>
+                  Theme
+                </Text>
+                <Flex align="center" gap="m">
+                  <Flex as="label" align="center" gap="s">
+                    <Checkbox
+                      name="theme"
+                      value="light"
+                      type="radio"
+                      checked={theme === 'light'}
+                      onChange={() => setTheme('light')}
+                    />
+                    Light
+                  </Flex>
+
+                  <Flex as="label" align="center" gap="s">
+                    <Checkbox
+                      name="theme"
+                      value="dark"
+                      type="radio"
+                      checked={theme === 'dark'}
+                      onChange={() => setTheme('dark')}
+                    />
+                    Dark
+                  </Flex>
+                </Flex>
+              </Flex>
+
               <Flex direction="column" gap="m">
                 <Text>
                   Copy and paste the following HTML to embed this agent on any
@@ -46,7 +84,7 @@ export const EmbedAgentModal = ({ entry, isOpen, setIsOpen }: Props) => {
                 <Code
                   language="html"
                   source={`<iframe 
-  src="https://app.near.ai/embed/${id}" 
+  src="https://app.near.ai/embed/${id}?theme=${theme}" 
   sandbox="allow-scripts allow-popups allow-same-origin allow-forms"
   style="border: none; height: 100svh;">
 </iframe>`}
@@ -60,13 +98,13 @@ export const EmbedAgentModal = ({ entry, isOpen, setIsOpen }: Props) => {
                   <Accordion.Trigger
                     style={{ width: 'auto', gap: 'var(--gap-s)' }}
                   >
-                    Customize
+                    Customize Metadata
                   </Accordion.Trigger>
 
                   <Accordion.Content>
                     <Text>
-                      You can customize how an agent is displayed by updating
-                      its <InlineCode>metadata.json</InlineCode>:
+                      You can further customize how an agent is displayed by
+                      updating its <InlineCode>metadata.json</InlineCode>:
                     </Text>
 
                     <Code
@@ -75,9 +113,14 @@ export const EmbedAgentModal = ({ entry, isOpen, setIsOpen }: Props) => {
   "details": {
     "agent": {
       "embed": {
-        "logo": "https://near.ai/logo-white.svg"
+        "logo": "https://images.com/logo.svg" | false
+      },
+      "welcome": {
+        "title": "Helpful Assistant",
+        "description": "How can I help you today?"
       }
-    }
+    },
+    "icon": "https://images.com/icon.svg"
   }
 }`}
                     />

--- a/hub/demo/src/components/Layout.tsx
+++ b/hub/demo/src/components/Layout.tsx
@@ -2,8 +2,8 @@
 
 import { PagodaUiProvider, Toaster } from '@near-pagoda/ui';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { type ReactNode } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { type ComponentProps, type ReactNode } from 'react';
 
 import { TRPCProvider } from '~/trpc/TRPCProvider';
 
@@ -14,9 +14,14 @@ import { NearInitializer } from './NearInitializer';
 import { ZustandHydration } from './ZustandHydration';
 
 export const Layout = ({ children }: { children: ReactNode }) => {
+  const params = useSearchParams();
+
   return (
     <PagodaUiProvider
       value={{
+        forcedTheme: params.get('theme') as NonNullable<
+          ComponentProps<typeof PagodaUiProvider>['value']
+        >['forcedTheme'],
         Link,
         useRouter,
       }}

--- a/hub/demo/src/components/Navigation.module.scss
+++ b/hub/demo/src/components/Navigation.module.scss
@@ -69,8 +69,8 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: flex-start;
   white-space: nowrap;
-  margin-right: auto;
   padding: 0.5rem 0;
 
   img {

--- a/hub/demo/src/components/Navigation.tsx
+++ b/hub/demo/src/components/Navigation.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ImageIcon, Placeholder, useTheme } from '@near-pagoda/ui';
+import { ImageIcon, useTheme } from '@near-pagoda/ui';
 import {
   BreakpointDisplay,
   Button,
@@ -123,7 +123,7 @@ export const Navigation = () => {
   const { embedded } = useEmbeddedWithinIframe();
   const hidden = path === SIGN_IN_CALLBACK_PATH;
   const { currentEntry, currentEntryId } = useCurrentEntry('agent', {
-    enabled: !embedded,
+    enabled: embedded,
   });
 
   useEffect(() => {
@@ -156,22 +156,21 @@ export const Navigation = () => {
   return (
     <header className={s.navigation}>
       {embedded ? (
-        <div className={s.embeddedLogo}>
-          {currentEntry ? (
-            <>
-              {currentEntry.details.agent?.embed?.logo ? (
-                <img
-                  src={currentEntry.details.agent.embed.logo}
-                  alt={currentEntry.name}
-                />
-              ) : (
-                <span className={s.logoTitle}>{currentEntry.name}</span>
-              )}
-            </>
-          ) : (
-            <Placeholder />
-          )}
-        </div>
+        <>
+          {currentEntry &&
+            currentEntry.details.agent?.embed?.logo !== false && (
+              <div className={s.embeddedLogo}>
+                {currentEntry.details.agent?.embed?.logo ? (
+                  <img
+                    src={currentEntry.details.agent.embed.logo}
+                    alt={currentEntry.name}
+                  />
+                ) : (
+                  <span className={s.logoTitle}>{currentEntry.name}</span>
+                )}
+              </div>
+            )}
+        </>
       ) : (
         <Link className={s.logo} href="/">
           <span className={s.logoNearAi}>NEAR AI</span>
@@ -400,61 +399,68 @@ export const Navigation = () => {
                 </Dropdown.Item>
               </Dropdown.Section>
 
-              {wallet && walletAccount ? (
-                <Dropdown.Section>
-                  <Dropdown.SectionContent>
-                    <Flex direction="column" gap="m">
-                      <Text size="text-xs" weight={600} uppercase>
-                        Payment Method
-                      </Text>
+              {!embedded && (
+                <>
+                  {/* https://github.com/nearai/nearai/issues/952 */}
 
-                      <Flex align="center" gap="s">
-                        <ImageIcon
-                          src={wallet.metadata.iconUrl}
-                          alt={wallet.metadata.name}
-                        />
-
-                        <Flex direction="column">
-                          <Text
-                            size="text-s"
-                            weight={600}
-                            color="sand-12"
-                            clampLines={1}
-                          >
-                            {walletAccount.accountId}
+                  {wallet && walletAccount ? (
+                    <Dropdown.Section>
+                      <Dropdown.SectionContent>
+                        <Flex direction="column" gap="m">
+                          <Text size="text-xs" weight={600} uppercase>
+                            Payment Method
                           </Text>
-                          <Text size="text-xs" clampLines={1}>
-                            {wallet.metadata.name}
+
+                          <Flex align="center" gap="s">
+                            <ImageIcon
+                              src={wallet.metadata.iconUrl}
+                              alt={wallet.metadata.name}
+                            />
+
+                            <Flex direction="column">
+                              <Text
+                                size="text-s"
+                                weight={600}
+                                color="sand-12"
+                                clampLines={1}
+                              >
+                                {walletAccount.accountId}
+                              </Text>
+                              <Text size="text-xs" clampLines={1}>
+                                {wallet.metadata.name}
+                              </Text>
+                            </Flex>
+                          </Flex>
+                        </Flex>
+                      </Dropdown.SectionContent>
+
+                      <Dropdown.Item onSelect={disconnectWallet}>
+                        <SvgIcon icon={<X />} />
+                        Disconnect
+                      </Dropdown.Item>
+                    </Dropdown.Section>
+                  ) : (
+                    <Dropdown.Section>
+                      <Dropdown.SectionContent>
+                        <Flex direction="column" gap="m">
+                          <Text size="text-xs" weight={600} uppercase>
+                            Payment Method
+                          </Text>
+
+                          <Text size="text-xs">
+                            Certain agent interactions require a connected
+                            wallet.
                           </Text>
                         </Flex>
-                      </Flex>
-                    </Flex>
-                  </Dropdown.SectionContent>
+                      </Dropdown.SectionContent>
 
-                  <Dropdown.Item onSelect={disconnectWallet}>
-                    <SvgIcon icon={<X />} />
-                    Disconnect
-                  </Dropdown.Item>
-                </Dropdown.Section>
-              ) : (
-                <Dropdown.Section>
-                  <Dropdown.SectionContent>
-                    <Flex direction="column" gap="m">
-                      <Text size="text-xs" weight={600} uppercase>
-                        Payment Method
-                      </Text>
-
-                      <Text size="text-xs">
-                        Certain agent interactions require a connected wallet.
-                      </Text>
-                    </Flex>
-                  </Dropdown.SectionContent>
-
-                  <Dropdown.Item onSelect={() => walletModal?.show()}>
-                    <SvgIcon icon={<Wallet />} />
-                    Add Payment Method
-                  </Dropdown.Item>
-                </Dropdown.Section>
+                      <Dropdown.Item onSelect={() => walletModal?.show()}>
+                        <SvgIcon icon={<Wallet />} />
+                        Add Payment Method
+                      </Dropdown.Item>
+                    </Dropdown.Section>
+                  )}
+                </>
               )}
             </Dropdown.Content>
           </Dropdown.Root>

--- a/hub/demo/src/components/SignInPrompt.tsx
+++ b/hub/demo/src/components/SignInPrompt.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Button, Container, Flex, Section, Text } from '@near-pagoda/ui';
-import { ArrowRight } from '@phosphor-icons/react';
 
 import { signIn } from '~/lib/auth';
 
@@ -17,13 +16,7 @@ export const SignInPrompt = ({ layout = 'horizontal-right' }: Props) => {
       justify={layout === 'horizontal-right' ? 'end' : 'space-between'}
     >
       <Text size="text-s">Please sign in to continue</Text>
-      <Button
-        variant="affirmative"
-        label="Sign In"
-        onClick={signIn}
-        size="small"
-        iconRight={<ArrowRight />}
-      />
+      <Button label="Sign In" onClick={signIn} size="small" />
     </Flex>
   );
 };
@@ -35,13 +28,7 @@ export const SignInPromptSection = () => {
         <Flex direction="column" gap="m" align="center">
           <Text size="text-l">Welcome</Text>
           <Text>Please sign in to continue</Text>
-          <Button
-            variant="affirmative"
-            label="Sign In"
-            onClick={signIn}
-            size="large"
-            iconRight={<ArrowRight />}
-          />
+          <Button label="Sign In" onClick={signIn} size="large" />
         </Flex>
       </Container>
     </Section>

--- a/hub/demo/src/components/threads/messages/Message.tsx
+++ b/hub/demo/src/components/threads/messages/Message.tsx
@@ -3,6 +3,8 @@
 import { Card, Flex, Text } from '@near-pagoda/ui';
 import { type ReactNode } from 'react';
 
+import { useCurrentEntry } from '~/hooks/entries';
+
 import { useThreadMessageContent } from '../ThreadMessageContentProvider';
 
 type Props = {
@@ -11,8 +13,13 @@ type Props = {
 };
 
 export const Message = ({ children, actions }: Props) => {
+  const { currentEntry } = useCurrentEntry('agent', {
+    refetchOnMount: false,
+  });
   const { message } = useThreadMessageContent();
   const showFooter = message.role !== 'user' || actions;
+  const assistantRoleLabel =
+    currentEntry?.details.agent?.assistant_role_label || 'Assistant';
 
   return (
     <Card
@@ -25,13 +32,8 @@ export const Message = ({ children, actions }: Props) => {
       {showFooter && (
         <Flex align="center" gap="m">
           {message.role !== 'user' && (
-            <Text
-              size="text-xs"
-              style={{
-                textTransform: 'capitalize',
-              }}
-            >
-              - {message.role}
+            <Text size="text-xs">
+              - {message.role === 'assistant' ? assistantRoleLabel : 'System'}
             </Text>
           )}
 

--- a/hub/demo/src/hooks/consumer.ts
+++ b/hub/demo/src/hooks/consumer.ts
@@ -5,5 +5,5 @@ import { useEmbeddedWithinIframe } from './embed';
 export function useConsumerModeEnabled() {
   const { embedded } = useEmbeddedWithinIframe();
   const consumerModeEnabled = env.NEXT_PUBLIC_CONSUMER_MODE || embedded;
-  return { consumerModeEnabled };
+  return { consumerModeEnabled, embedded };
 }

--- a/hub/demo/src/hooks/entries.ts
+++ b/hub/demo/src/hooks/entries.ts
@@ -40,14 +40,19 @@ export function useCurrentEntryParams(overrides?: {
 
 export function useCurrentEntry(
   category: EntryCategory,
-  overrides?: {
+  options?: {
     enabled?: boolean;
-    namespace?: string;
-    name?: string;
-    version?: string;
+    refetchOnMount?: boolean;
+    overrides?: {
+      namespace?: string;
+      name?: string;
+      version?: string;
+    };
   },
 ) {
-  const { id, namespace, name, version } = useCurrentEntryParams(overrides);
+  const { id, namespace, name, version } = useCurrentEntryParams(
+    options?.overrides,
+  );
 
   const entriesQuery = trpc.hub.entries.useQuery(
     {
@@ -56,8 +61,8 @@ export function useCurrentEntry(
       showLatestVersion: false,
     },
     {
-      enabled:
-        typeof overrides?.enabled === 'boolean' ? overrides.enabled : true,
+      refetchOnMount: options?.refetchOnMount,
+      enabled: typeof options?.enabled === 'boolean' ? options.enabled : true,
     },
   );
 

--- a/hub/demo/src/lib/models.ts
+++ b/hub/demo/src/lib/models.ts
@@ -81,9 +81,15 @@ export const entryDetailsModel = z.intersection(
     .object({
       agent: z
         .object({
+          assistant_role_label: z.string(),
           defaults: z
             .object({
               max_iterations: z.number(),
+            })
+            .partial(),
+          embed: z
+            .object({
+              logo: z.string().or(z.literal(false)),
             })
             .partial(),
           html_height: z.enum(['auto']).or(z.string()).default('auto'),
@@ -94,11 +100,6 @@ export const entryDetailsModel = z.intersection(
               title: z.string(),
               description: z.string(),
               icon: z.string(),
-            })
-            .partial(),
-          embed: z
-            .object({
-              logo: z.string(),
             })
             .partial(),
         })


### PR DESCRIPTION
- Fixed embed logo stretching bug for mobile and Safari
- More agent metadata customization options
- Set `agent.embed.logo: false` to display no logo or text in header
- Set `agent.assistant_role_label` to override default `Assistant` label on each message from the `assistant` role
- Allow developer to set theme via query param. This would allow them to dynamically change the theme between light/dark mode based on their own website user preferences.

<img width="883" alt="Screenshot 2025-02-26 at 11 53 14 AM" src="https://github.com/user-attachments/assets/1a4bab2d-52f0-4a78-9401-4e93c0626d4e" />
