### PR TITLE
Simplified and improved iframe resize handling + various UI improvements

### DIFF
--- a/hub/demo/src/components/AgentRunner.tsx
+++ b/hub/demo/src/components/AgentRunner.tsx
@@ -269,7 +269,12 @@ export const AgentRunner = ({
   };
 
   const startNewThread = () => {
-    updateQueryPath({ threadId: null });
+    updateQueryPath({
+      threadId: null,
+      view: null,
+      showLogs: null,
+      initialUserMessage: null,
+    });
     form.setValue('new_message', '');
     form.setFocus('new_message');
   };

--- a/hub/demo/src/components/AgentRunner.tsx
+++ b/hub/demo/src/components/AgentRunner.tsx
@@ -121,6 +121,9 @@ export const AgentRunner = ({
     useState(false);
   const formRef = useRef<HTMLFormElement | null>(null);
 
+  const clearOptimisticMessages = useThreadsStore(
+    (store) => store.clearOptimisticMessages,
+  );
   const addOptimisticMessages = useThreadsStore(
     (store) => store.addOptimisticMessages,
   );
@@ -130,7 +133,6 @@ export const AgentRunner = ({
   const initialUserMessageSent = useRef(false);
   const chatMutationThreadId = useRef('');
   const chatMutationStartedAt = useRef<Date | null>(null);
-  const resetThreadsStore = useThreadsStore((store) => store.reset);
   const setThread = useThreadsStore((store) => store.setThread);
   const threadsById = useThreadsStore((store) => store.threadsById);
   const setAddMessage = useThreadsStore((store) => store.setAddMessage);
@@ -275,6 +277,7 @@ export const AgentRunner = ({
       showLogs: null,
       initialUserMessage: null,
     });
+    clearOptimisticMessages();
     form.setValue('new_message', '');
     form.setFocus('new_message');
   };
@@ -351,9 +354,9 @@ export const AgentRunner = ({
       initialUserMessageSent.current = false;
       chatMutationThreadId.current = '';
       chatMutationStartedAt.current = null;
-      resetThreadsStore();
+      clearOptimisticMessages();
     }
-  }, [threadId, resetThreadsStore]);
+  }, [threadId, clearOptimisticMessages]);
 
   useEffect(() => {
     form.reset();

--- a/hub/demo/src/components/lib/Code.tsx
+++ b/hub/demo/src/components/lib/Code.tsx
@@ -5,7 +5,7 @@
 import { useTheme } from '@near-pagoda/ui';
 import { Button, copyTextToClipboard, Tooltip } from '@near-pagoda/ui';
 import { Copy } from '@phosphor-icons/react';
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import {
   atomOneDark,
@@ -54,58 +54,62 @@ function normalizeLanguage(input: string | null | undefined) {
   return value;
 }
 
-export const Code = ({
-  bleed,
-  showCopyButton = true,
-  showLineNumbers = true,
-  ...props
-}: Props) => {
-  const { resolvedTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-  const language = normalizeLanguage(props.language);
-  const source = props.source?.replace(/[\n]+$/, '').replace(/^[\n]+/, '');
+export const Code = memo(
+  ({
+    bleed,
+    showCopyButton = true,
+    showLineNumbers = true,
+    ...props
+  }: Props) => {
+    const { resolvedTheme } = useTheme();
+    const [mounted, setMounted] = useState(false);
+    const language = normalizeLanguage(props.language);
+    const source = props.source?.replace(/[\n]+$/, '').replace(/^[\n]+/, '');
 
-  const style =
-    mounted && resolvedTheme === 'dark' ? atomOneDark : atomOneLight;
+    const style =
+      mounted && resolvedTheme === 'dark' ? atomOneDark : atomOneLight;
 
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+    useEffect(() => {
+      setMounted(true);
+    }, []);
 
-  if (!mounted) return null;
+    if (!mounted) return null;
 
-  return (
-    <div
-      className={s.code}
-      data-bleed={bleed}
-      data-copy={showCopyButton}
-      data-language={language}
-    >
-      {showCopyButton && (
-        <Tooltip asChild content="Copy to clipboard">
-          <Button
-            label="Copy code to clipboard"
-            icon={<Copy />}
-            variant="secondary"
-            size="small"
-            fill="ghost"
-            onClick={() => source && copyTextToClipboard(source)}
-            className={s.copyButton}
-            tabIndex={-1}
-          />
-        </Tooltip>
-      )}
+    return (
+      <div
+        className={s.code}
+        data-bleed={bleed}
+        data-copy={showCopyButton}
+        data-language={language}
+      >
+        {showCopyButton && (
+          <Tooltip asChild content="Copy to clipboard">
+            <Button
+              label="Copy code to clipboard"
+              icon={<Copy />}
+              variant="secondary"
+              size="small"
+              fill="ghost"
+              onClick={() => source && copyTextToClipboard(source)}
+              className={s.copyButton}
+              tabIndex={-1}
+            />
+          </Tooltip>
+        )}
 
-      {source && (
-        <SyntaxHighlighter
-          PreTag="div"
-          language={language ?? ''}
-          style={style}
-          showLineNumbers={showLineNumbers}
-        >
-          {source}
-        </SyntaxHighlighter>
-      )}
-    </div>
-  );
-};
+        {source && (
+          <SyntaxHighlighter
+            PreTag="div"
+            language={language ?? ''}
+            style={style}
+            showLineNumbers={showLineNumbers}
+          >
+            {source}
+          </SyntaxHighlighter>
+        )}
+      </div>
+    );
+  },
+);
+
+Code.displayName = 'Code';

--- a/hub/demo/src/components/lib/Markdown.tsx
+++ b/hub/demo/src/components/lib/Markdown.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Table } from '@near-pagoda/ui';
+import { memo } from 'react';
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { visit } from 'unist-util-visit';
@@ -22,7 +23,7 @@ function urlTransform(url: string) {
   return defaultUrlTransform(url);
 }
 
-export const Markdown = (props: Props) => {
+export const Markdown = memo((props: Props) => {
   const content = props.content?.replace(/\s```/g, '\n```');
 
   return (
@@ -83,4 +84,6 @@ export const Markdown = (props: Props) => {
       </ReactMarkdown>
     </div>
   );
-};
+});
+
+Markdown.displayName = 'Markdown';

--- a/hub/demo/src/components/lib/Sidebar/Sidebar.module.scss
+++ b/hub/demo/src/components/lib/Sidebar/Sidebar.module.scss
@@ -54,7 +54,10 @@
   max-height: calc(100svh - max(var(--header-height), var(--sidebar-root-top)));
   min-height: 0;
   flex-shrink: 0;
-  box-shadow: var(--shadow-card-with-outline);
+  box-shadow:
+    1px 0px 0px rgba(0, 0, 0, 0.025),
+    -1px 0px 0px rgba(0, 0, 0, 0.025),
+    var(--shadow-card);
   overflow: hidden;
 
   @media (max-width: $tabletBreakpointMaxWidth) {

--- a/hub/demo/src/components/lib/Sidebar/Sidebar.module.scss
+++ b/hub/demo/src/components/lib/Sidebar/Sidebar.module.scss
@@ -46,6 +46,7 @@
 }
 
 .sidebar {
+  --open-transition-speed: 300ms;
   position: sticky;
   z-index: 250;
   top: var(--header-height);
@@ -53,23 +54,36 @@
   max-height: calc(100svh - max(var(--header-height), var(--sidebar-root-top)));
   min-height: 0;
   flex-shrink: 0;
-  box-shadow: 0 0 1rem rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-card-with-outline);
+  overflow: hidden;
 
   @media (max-width: $tabletBreakpointMaxWidth) {
+    z-index: 750;
     position: fixed;
-    right: 0;
-    bottom: 0;
-    width: 0vw;
-    bottom: 0;
+    max-height: none;
+    height: 0px;
     opacity: 0;
+    top: unset;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    opacity: 0;
+    box-shadow: none;
+    background: var(--sand-4);
     transition:
-      width 300ms,
-      opacity 300ms;
+      height 0ms var(--open-transition-speed),
+      opacity var(--open-transition-speed);
 
     &[data-open-small-screens='true'] {
-      display: flex;
-      width: 100vw;
+      height: 100svh;
       opacity: 1;
+      transition:
+        height 0ms,
+        opacity var(--open-transition-speed);
+
+      .sidebarContent {
+        transform: translateY(0%);
+      }
     }
   }
 }
@@ -78,17 +92,18 @@
   width: 18vw;
   min-width: 260px;
   flex-shrink: 0;
-  background: var(--sand-2);
   overflow: auto;
   scroll-behavior: smooth;
   height: 100%;
+  background: var(--sand-2);
+  transition: transform var(--open-transition-speed);
 
   @include hideScrollbar();
 
   @media (max-width: $tabletBreakpointMaxWidth) {
-    width: 100vw;
-    padding-top: 0 !important;
+    width: 100%;
     overscroll-behavior: contain;
+    transform: translateY(100%);
   }
 }
 
@@ -112,9 +127,27 @@
 }
 
 .sidebarCloseButton {
-  position: absolute;
-  top: var(--gap-m);
-  right: var(--gap-m);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  display: flex;
+  width: 100%;
+  height: var(--header-height);
+  border: none;
+  outline: none;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  background: var(--sand-4);
+  box-shadow:
+    0 0 10px rgba(0, 0, 0, 0.1),
+    0 1px 1px rgba(0, 0, 0, 0.05);
+  transition: var(--transitions);
+
+  &:hover,
+  &:focus-visible {
+    color: var(--sand-12);
+  }
 
   @media (min-width: $tabletBreakpointMaxWidth) {
     display: none !important;

--- a/hub/demo/src/components/lib/Sidebar/Sidebar.tsx
+++ b/hub/demo/src/components/lib/Sidebar/Sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Button } from '@near-pagoda/ui';
-import { X } from '@phosphor-icons/react';
+import { SvgIcon } from '@near-pagoda/ui';
+import { CaretDown } from '@phosphor-icons/react';
 import { type CSSProperties, type ReactNode, useEffect, useRef } from 'react';
 
 import { Footer } from '~/components/Footer';
@@ -66,30 +66,34 @@ type SidebarProps = {
   children: ReactNode;
   openForSmallScreens: boolean;
   setOpenForSmallScreens: (open: boolean) => unknown;
-  width?: string;
 };
 
 export const Sidebar = ({
   children,
   openForSmallScreens,
   setOpenForSmallScreens,
-  width,
 }: SidebarProps) => {
   return (
     <div className={s.sidebar} data-open-small-screens={openForSmallScreens}>
-      <div className={s.sidebarContent} style={{ width, minWidth: width }}>
-        <div className={s.sidebarContentInner}>
-          <Button
-            label="Close"
-            icon={<X weight="bold" />}
-            onClick={() => setOpenForSmallScreens(false)}
-            className={s.sidebarCloseButton}
-            fill="ghost"
-            size="x-small"
-          />
+      <div className={s.sidebarContent}>
+        <button
+          type="button"
+          onPointerDownCapture={(event) => {
+            event.stopPropagation();
+            setOpenForSmallScreens(false);
+          }}
+          onPointerUpCapture={(event) => {
+            event.stopPropagation();
+          }}
+          onClickCapture={(event) => {
+            event.stopPropagation();
+          }}
+          className={s.sidebarCloseButton}
+        >
+          <SvgIcon icon={<CaretDown weight="bold" />} size="s" />
+        </button>
 
-          {children}
-        </div>
+        <div className={s.sidebarContentInner}>{children}</div>
       </div>
     </div>
   );

--- a/hub/demo/src/components/threads/ThreadFileModal.tsx
+++ b/hub/demo/src/components/threads/ThreadFileModal.tsx
@@ -5,6 +5,7 @@ import {
   Flex,
   PlaceholderStack,
   Tooltip,
+  useDebouncedValue,
 } from '@near-pagoda/ui';
 import { Copy, Eye, MarkdownLogo } from '@phosphor-icons/react';
 import { useState } from 'react';
@@ -27,8 +28,11 @@ export const ThreadFileModal = ({
   openedFileName,
   setOpenedFileName,
 }: Props) => {
-  const file =
-    filesByName && openedFileName ? filesByName[openedFileName] : undefined;
+  const file = useDebouncedValue(
+    filesByName && openedFileName ? filesByName[openedFileName] : undefined,
+    25,
+  );
+
   const isImage = filePathIsImage(file?.filename);
   const language = file && filePathToCodeLanguage(file.filename);
   const isMarkdown = language === 'markdown';

--- a/hub/demo/src/components/threads/ThreadsSidebar.tsx
+++ b/hub/demo/src/components/threads/ThreadsSidebar.tsx
@@ -94,12 +94,7 @@ export const ThreadsSidebar = ({
       setOpenForSmallScreens={setOpenForSmallScreens}
     >
       <Flex align="center" gap="s">
-        <Text
-          size="text-xs"
-          weight={600}
-          uppercase
-          style={{ marginRight: 'auto' }}
-        >
+        <Text size="text-xs" weight={600} uppercase>
           Threads
         </Text>
 
@@ -108,7 +103,7 @@ export const ThreadsSidebar = ({
             label="New Thread"
             icon={<Plus weight="bold" />}
             variant="affirmative"
-            fill="outline"
+            fill="ghost"
             size="x-small"
             onClick={onRequestNewThread}
           />

--- a/hub/demo/src/components/threads/messages/Message.tsx
+++ b/hub/demo/src/components/threads/messages/Message.tsx
@@ -25,7 +25,10 @@ export const Message = ({ children, actions }: Props) => {
     <Card
       animateIn
       background={message.role === 'user' ? 'sand-2' : undefined}
-      style={message.role === 'user' ? { alignSelf: 'end' } : undefined}
+      style={{
+        maxWidth: '100%',
+        alignSelf: message.role === 'user' ? 'end' : undefined,
+      }}
     >
       {children}
 

--- a/hub/demo/src/examples/agent-html-output/fill-available-space.html
+++ b/hub/demo/src/examples/agent-html-output/fill-available-space.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <style>
+      html,
+      body {
+        height: 100%;
+        background: #fff;
+      }
+
+      .container {
+        position: relative;
+        overflow: hidden;
+        height: 100%;
+        min-height: 300px;
+        display: grid;
+        grid-template-columns: 1fr 150px;
+        gap: 1rem;
+        justify-content: stretch;
+        align-items: stretch;
+      }
+
+      .stack {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .box {
+        border: 2px solid;
+        padding: 1rem;
+        height: 100%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="container">
+      <div class="stack">
+        <div class="box">Content 1</div>
+        <div class="box">Content 2</div>
+      </div>
+
+      <div class="box">Sidebar</div>
+    </div>
+  </body>
+</html>

--- a/hub/demo/src/stores/threads.ts
+++ b/hub/demo/src/stores/threads.ts
@@ -39,7 +39,7 @@ type ThreadsStore = {
     currentThreadId: string | null | undefined,
     inputs: z.infer<typeof chatWithAgentModel>[],
   ) => void;
-  reset: () => void;
+  clearOptimisticMessages: () => void;
   setAddMessage: (addMessage: ThreadsStore['addMessage']) => void;
   setThread: (
     thread: Partial<Omit<AppRouterOutputs['hub']['thread'], 'id'>> & {
@@ -97,7 +97,7 @@ const store: StateCreator<ThreadsStore> = (set, get) => ({
     set({ optimisticMessages });
   },
 
-  reset: () => set({ optimisticMessages: [] }),
+  clearOptimisticMessages: () => set({ optimisticMessages: [] }),
 
   setAddMessage: (addMessage) => set({ addMessage }),
 


### PR DESCRIPTION
- Reset additional query param values when the user clicks "start new thread"
- Fixed horizontal overflow issue with certain thread messages
- Simplified unnecessarily complex iframe resize logic that wasn't very helpful
- Improved sidebar drawer open/close UI for smaller screens (viewing threads, file outputs)
- Recomputing iframe size on window resize event
- Improve performance of opening larger thread output files in the sidebar via memoization of `Code` and `Markdown`. In some cases, the file content modal would be extremely laggy while scrolling. This fixes that.
- Added an example HTML file (`src/examples/agent-html-output/fill-available-space.html`) which will be helpful to reference as a layout template until we get more official docs setup regarding `index.html` agent output.

Did my best to thoroughly test all changes locally. Should be good to go.