### PR TITLE
Modified Message content to Union[List, str]

### DIFF
--- a/hub/api/v1/completions.py
+++ b/hub/api/v1/completions.py
@@ -1,7 +1,7 @@
 import json
 from enum import Enum
 from os import getenv
-from typing import Callable, List
+from typing import Callable, List, Union
 
 from dotenv import load_dotenv
 from nearai.shared.client_config import DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT
@@ -62,16 +62,16 @@ class Message(BaseModel):
     """A chat message."""
 
     role: str
-    content: List[dict]
+    content: Union[List, str]
 
     @field_validator("content", mode="before")
     @classmethod
     def ensure_string_content(cls, v):
-        """Convert None to empty string and ensure content is always a string."""
+        """Ensure content within the messages is always a string"""
         if v is None:
             return ""
 
-        # Iterate recursively over the object, convert None to empty string
+        # Iterate recursively over the object, converting values to str
         if isinstance(v, list):
             return [cls.ensure_string_content(i) for i in v]
         elif isinstance(v, dict):

--- a/hub/api/v1/completions.py
+++ b/hub/api/v1/completions.py
@@ -67,7 +67,7 @@ class Message(BaseModel):
     @field_validator("content", mode="before")
     @classmethod
     def ensure_string_content(cls, v):
-        """Ensure content within the messages is always a string"""
+        """Ensure content within the messages is always a string."""
         if v is None:
             return ""
 

--- a/hub/api/v1/completions.py
+++ b/hub/api/v1/completions.py
@@ -1,7 +1,7 @@
 import json
 from enum import Enum
 from os import getenv
-from typing import Callable
+from typing import Callable, List
 
 from dotenv import load_dotenv
 from nearai.shared.client_config import DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT
@@ -62,12 +62,19 @@ class Message(BaseModel):
     """A chat message."""
 
     role: str
-    content: str = ""
+    content: List[dict]
 
     @field_validator("content", mode="before")
     @classmethod
     def ensure_string_content(cls, v):
         """Convert None to empty string and ensure content is always a string."""
-        if not v:
+        if v is None:
             return ""
-        return str(v)  # Convert any non-None value to string
+
+        # Iterate recursively over the object, convert None to empty string
+        if isinstance(v, list):
+            return [cls.ensure_string_content(i) for i in v]
+        elif isinstance(v, dict):
+            return {k: cls.ensure_string_content(v) for k, v in v.items()}
+        else:
+            return str(v)


### PR DESCRIPTION
So far we are always casting all messages to strings, which destroys the structure of the `messages`

While most of the time this is not a problem, with models that are expecting a very specific structure (e.g. `phi-3-vision-128k-instruct`) passing a string instead of a `List[dict]` will make the model hallucinate and actually fail at the task they are asked to perform

This PR modifies the behaviour of our `ensure_string_content` function, so it iteratively transforms the `values` within the list passed to `messages` instead of the list itself 