### PR TITLE
Fix local path problems

### DIFF
--- a/nearai/lib.py
+++ b/nearai/lib.py
@@ -58,7 +58,7 @@ def log(*, target: str, **content: Any) -> None:
     print("WARNING: Logging is disabled")
 
 
-def check_metadata(path: Path):
+def check_metadata_present(path: Path):
     if not path.exists():
         print(f"Metadata file not found: {path.absolute()}")
         print("Create a metadata file with `nearai registry metadata_template`")


### PR DESCRIPTION
Tested with:

```
nearai agent interactive ~/.nearai/registry/alomonos.near/example-travel-agent/1.0.1 --local # metadata.json contains another version
nearai agent interactive alomonos.near/example-travel-agent/1.0.1 --local # metadata.json contains another version
nearai agent interactive alomonos.near/example-travel-agent/1.0.1 # works with both local folder present or absent. runs registry version
nearai agent interactive ~/.nearai/registry/alomonos.near/example-travel-agent/1.0.1 # crashes as expected
nearai agent interactive ~/projects/nearai_langchain/examples/nearai_fireworks_usage --local
```

fixes #962 
fixes #793