### PR TITLE
Support .gitignore file when uploading to registry

### DIFF
--- a/nearai/registry.py
+++ b/nearai/registry.py
@@ -230,6 +230,7 @@ class Registry:
             gitignore_path = path / ".gitignore"
             if gitignore_path.exists() and gitignore_path.is_file():
                 with open(gitignore_path, "r") as f:
+                    print(".gitignore file detected. Will filter out git ignore files.\n")
                     # Start with Git's default ignore patterns
                     default_ignore_patterns = [
                         # Git internal directories
@@ -336,6 +337,7 @@ class Registry:
             total_size += size
 
             all_files.append((file, relative, size))
+            print(f"U   {relative}")
 
         pbar = tqdm(total=total_size, unit="B", unit_scale=True, disable=not show_progress)
         for file, relative, size in all_files:


### PR DESCRIPTION
Also printing list of files to be uploaded:

```
[0] nearai registry upload /Users/antonlomonos/.nearai/registry/alomonos.near/gitignore-test/latest
.gitignore file detected. Will filter out git ignore files.

47155 files are filtered out and will not be uploaded.

Files to be uploaded:
U   agent.py

100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 296/296 [00:01<00:00, 274B/s]
namespace='alomonos.near' name='gitignore-test' version='0.0.2'
```

Fixes #860 