### PR TITLE
feat: image-to-image support for fireworks.ai

### DIFF
--- a/hub/api/v1/images.py
+++ b/hub/api/v1/images.py
@@ -40,7 +40,7 @@ class FireworksImageGenerator:
         fireworks_params = {
             "prompt": kwargs.get("prompt"),
             "init_image": kwargs.get("init_image"),
-            "image_strength": kwargs.get("image_strength", 0.7),
+            "image_strength": kwargs.get("image_strength"),
             "cfg_scale": kwargs.get("cfg_scale", 7.0),
             "height": kwargs.get("height", 1024),
             "width": kwargs.get("width", 1024),
@@ -64,6 +64,10 @@ class FireworksImageGenerator:
                 init_image = self._decode_image(base64_image)
                 fireworks_params.update({"init_image": init_image})
 
+                # set the image strength to 0.7 if it is not provided
+                if kwargs.get("image_strength") is None:
+                    fireworks_params.update({"image_strength": 0.7})
+
                 # also check if control_image is received
                 if kwargs.get("control_image"):
                     base64_image = kwargs.get("control_image")
@@ -75,8 +79,6 @@ class FireworksImageGenerator:
                 answer: Answer = self.inference_client.text_to_image(**fireworks_params)
             if answer.image is None:
                 raise RuntimeError(f"No return image, {answer.finish_reason}")
-
-
 
             buffered = io.BytesIO()
             answer.image.save(buffered, format="JPEG")

--- a/hub/api/v1/images.py
+++ b/hub/api/v1/images.py
@@ -1,3 +1,5 @@
+import base64
+import io
 import os
 from typing import Protocol
 
@@ -18,6 +20,11 @@ class FireworksImageGenerator:
             raise ValueError("FIREWORKS_API_KEY environment variable is not set")
         self.inference_client = ImageInference(model="playground-v2-1024px-aesthetic")
 
+    def _decode_image(self, base64_image: str) -> io.BytesIO:
+        image_buffer = io.BytesIO(base64.b64decode(base64_image))
+        image_buffer.seek(0)
+        return image_buffer
+
     def generate(self, **kwargs) -> dict:
         """Generate images using the Fireworks API.
 
@@ -32,6 +39,8 @@ class FireworksImageGenerator:
         """
         fireworks_params = {
             "prompt": kwargs.get("prompt"),
+            "init_image": kwargs.get("init_image"),
+            "image_strength": kwargs.get("image_strength", 0.7),
             "cfg_scale": kwargs.get("cfg_scale", 7.0),
             "height": kwargs.get("height", 1024),
             "width": kwargs.get("width", 1024),
@@ -40,16 +49,34 @@ class FireworksImageGenerator:
             "seed": kwargs.get("seed"),
             "safety_check": kwargs.get("safety_check", False),
             "output_image_format": "JPG",
+            "control_image": kwargs.get("control_image"),
+            "control_net_name": kwargs.get("control_net_name"),
+            "conditioning_scale": kwargs.get("conditioning_scale"),
         }
+
         fireworks_params = {k: v for k, v in fireworks_params.items() if v is not None}
 
         try:
-            answer: Answer = self.inference_client.text_to_image(**fireworks_params)
+            if kwargs.get("init_image"):
+                # run image to image if init_image is found
+                # decode the init_image (fireworks expects bytes, PIL or a file -- not base64)
+                base64_image = kwargs.get("init_image")
+                init_image = self._decode_image(base64_image)
+                fireworks_params.update({"init_image": init_image})
+
+                # also check if control_image is received
+                if kwargs.get("control_image"):
+                    base64_image = kwargs.get("control_image")
+                    control_image = self._decode_image(base64_image)
+                    fireworks_params.update({"control_image": control_image})
+
+                answer: Answer = self.inference_client.image_to_image(**fireworks_params)
+            else:
+                answer: Answer = self.inference_client.text_to_image(**fireworks_params)
             if answer.image is None:
                 raise RuntimeError(f"No return image, {answer.finish_reason}")
 
-            import base64
-            import io
+
 
             buffered = io.BytesIO()
             answer.image.save(buffered, format="JPEG")

--- a/hub/api/v1/images.py
+++ b/hub/api/v1/images.py
@@ -57,10 +57,11 @@ class FireworksImageGenerator:
         fireworks_params = {k: v for k, v in fireworks_params.items() if v is not None}
 
         try:
+            answer: Answer
             if kwargs.get("init_image"):
                 # run image to image if init_image is found
                 # decode the init_image (fireworks expects bytes, PIL or a file -- not base64)
-                base64_image = kwargs.get("init_image")
+                base64_image = str(kwargs.get("init_image"))
                 init_image = self._decode_image(base64_image)
                 fireworks_params.update({"init_image": init_image})
 
@@ -70,13 +71,13 @@ class FireworksImageGenerator:
 
                 # also check if control_image is received
                 if kwargs.get("control_image"):
-                    base64_image = kwargs.get("control_image")
+                    base64_image = str(kwargs.get("control_image"))
                     control_image = self._decode_image(base64_image)
                     fireworks_params.update({"control_image": control_image})
 
-                answer: Answer = self.inference_client.image_to_image(**fireworks_params)
+                answer = self.inference_client.image_to_image(**fireworks_params)
             else:
-                answer: Answer = self.inference_client.text_to_image(**fireworks_params)
+                answer = self.inference_client.text_to_image(**fireworks_params)
             if answer.image is None:
                 raise RuntimeError(f"No return image, {answer.finish_reason}")
 

--- a/hub/api/v1/routes.py
+++ b/hub/api/v1/routes.py
@@ -100,7 +100,7 @@ class ImageGenerationRequest(BaseModel):
     model: str = f"fireworks{PROVIDER_MODEL_SEP}accounts/fireworks/models/playground-v2-5-1024px-aesthetic"
     provider: Optional[str] = None
     init_image: Optional[str] = None
-    image_strength: Optional[float] = 0.7
+    image_strength: Optional[float] = None
     control_image: Optional[str] = None
     control_net_name: Optional[str] = None
     conditioning_scale: Optional[float] = None

--- a/hub/api/v1/routes.py
+++ b/hub/api/v1/routes.py
@@ -99,6 +99,15 @@ class ImageGenerationRequest(BaseModel):
     """A text description of the desired image(s)."""
     model: str = f"fireworks{PROVIDER_MODEL_SEP}accounts/fireworks/models/playground-v2-5-1024px-aesthetic"
     provider: Optional[str] = None
+    init_image: Optional[str] = None
+    image_strength: Optional[float] = 0.7
+    control_image: Optional[str] = None
+    control_net_name: Optional[str] = None
+    conditioning_scale: Optional[float] = None
+    cfg_scale: Optional[float] = None
+    sampler: Optional[str] = None
+    steps: Optional[int] = None
+    seed: Optional[int] = 0
 
     @field_validator("model")
     @classmethod


### PR DESCRIPTION
in `routes.py`:
- added necessary class attributes to `ImageGenerationRequest`

in `images.py`:
- added necessary image to image parameters to the `fireworks_params` dict
- handle image to image generation when `init_image` is present in the request, otherwise run text to image generation
- moved base64 and io imports to top of the file

fireworks api reference: https://fireworks.ai/models/fireworks/stable-diffusion-xl-1024-v1-0