### PR TITLE
feat: Forking agents now removes X event triggers

### DIFF
--- a/hub/api/v1/registry.py
+++ b/hub/api/v1/registry.py
@@ -663,6 +663,20 @@ def fork_entry(
             show_entry=True,
         )
 
+        # Remove X (Twitter) event triggers from the forked entry's details
+        if "triggers" in new_entry.details:
+            triggers = new_entry.details["triggers"]
+            if "events" in triggers:
+                events = triggers["events"]
+                if "x_mentions" in events:
+                    del events["x_mentions"]
+                # Optional: Remove the events object if empty after deletion
+                if not events:
+                    del triggers["events"]
+            # Optional: Remove the triggers object if empty after deletions
+            if not triggers:
+                del new_entry.details["triggers"]
+
         new_entry_collision_check = session.exec(
             select(RegistryEntry).where(
                 RegistryEntry.category == new_entry.category,


### PR DESCRIPTION
Forking agents now removes X (Twitter) event triggers to prevent scheduler extra run. Ensures forked agents start clean, requiring users to configure their own X integrations.

to resolve https://github.com/nearai/nearai/issues/981