### PR TITLE
Fix url provider bug in evaluation entry

### DIFF
--- a/nearai/evaluation.py
+++ b/nearai/evaluation.py
@@ -1,6 +1,6 @@
 import json
-from pathlib import Path
 import re
+from pathlib import Path
 from textwrap import fill
 from typing import Any, Dict, List, Union
 

--- a/nearai/evaluation.py
+++ b/nearai/evaluation.py
@@ -109,6 +109,8 @@ def upload_evaluation(
         key += f"_version_{version}"
     if provider != "":
         metrics[EVALUATED_ENTRY_METADATA]["provider"] = provider
+        # Url providers like 'https://api.openai.com/v1' can't be included into registry entry name
+        # because of special characters.
         clean_provider = re.sub(r'[^a-zA-Z0-9_\-.]', '_', provider)
         key += f"_provider_{clean_provider}"
 

--- a/nearai/evaluation.py
+++ b/nearai/evaluation.py
@@ -111,7 +111,7 @@ def upload_evaluation(
         metrics[EVALUATED_ENTRY_METADATA]["provider"] = provider
         # Url providers like 'https://api.openai.com/v1' can't be included into registry entry name
         # because of special characters.
-        clean_provider = re.sub(r'[^a-zA-Z0-9_\-.]', '_', provider)
+        clean_provider = re.sub(r"[^a-zA-Z0-9_\-.]", "_", provider)
         key += f"_provider_{clean_provider}"
 
     entry_path = get_registry_folder() / key

--- a/nearai/evaluation.py
+++ b/nearai/evaluation.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import re
 from textwrap import fill
 from typing import Any, Dict, List, Union
 
@@ -108,7 +109,8 @@ def upload_evaluation(
         key += f"_version_{version}"
     if provider != "":
         metrics[EVALUATED_ENTRY_METADATA]["provider"] = provider
-        key += f"_provider_{provider}"
+        clean_provider = re.sub(r'[^a-zA-Z0-9_\-.]', '_', provider)
+        key += f"_provider_{clean_provider}"
 
     entry_path = get_registry_folder() / key
     # Create folder entry_path if not present


### PR DESCRIPTION
Follow up to https://github.com/nearai/nearai/pull/858

Url providers like 'https://api.openai.com/v1' can't be included into registry entry name because of special characters.