### PR TITLE
Fix OpenSSL Conflict in Docker Build

### DIFF
--- a/aws_runner/py_runner/Dockerfile
+++ b/aws_runner/py_runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/lambda/python:3.11
 
-RUN yum install -y gcc libffi-devel openssl-devel shadow-utils acl && \
+RUN yum install -y gcc libffi-devel openssl-devel-1:1.0.2k-24.amzn2.0.14 shadow-utils acl && \
     yum clean all && \
     rm -rf /var/cache/yum
 


### PR DESCRIPTION
The error occurred due to a conflict between openssl-devel and openssl-snapsafe-libs. The default openssl-devel version was incompatible, causing a dependency resolution failure.

Explicitly set openssl-devel to 1.0.2k-24.amzn2.0.14 to match the expected version and resolve the conflict.

```
8.832 --> Processing Conflict: 1:openssl-snapsafe-libs-1.0.2k-24.amzn2.0.14.x86_64 conflicts openssl-libs
8.871 --> Finished Dependency Resolution
8.872 Error: openssl-snapsafe-libs conflicts with 1:openssl-libs-1.0.2k-24.amzn2.0.15.x86_64
8.872  You could try using --skip-broken to work around the problem
```