### PR TITLE
Account for name extensions in name matching

### DIFF
--- a/nearai/shared/naming.py
+++ b/nearai/shared/naming.py
@@ -8,7 +8,7 @@ def get_canonical_name(name: str) -> str:
 
     Applies such transformations:
     1. All letters lowercase.
-    2. Strips '.near' and '.ai' extensions.
+    2. Strips '.near' extensions.
     3. Convert '.' between digits to 'p'.
     4. Convert '<not letter>v<digit>' -> '<not letter><digit>'
     5. Remove all non-alphanumeric characters except between digits.
@@ -22,9 +22,6 @@ def get_canonical_name(name: str) -> str:
     # Strip .near extension if present
     if name.endswith(".near"):
         name = name[:-5]  # Remove last 5 characters ('.near')
-    # Strip .ai extension if present
-    if name.endswith(".ai"):
-        name = name[:-3]  # Remove last 3 characters ('.ai')
     # Convert '.' between digits to 'p'
     name = re.sub(r"(\d)\.(\d)", r"\1p\2", name)
     # Convert '<digit>v<digit>' -> '<digit>_<digit>'

--- a/nearai/shared/naming.py
+++ b/nearai/shared/naming.py
@@ -8,16 +8,23 @@ def get_canonical_name(name: str) -> str:
 
     Applies such transformations:
     1. All letters lowercase.
-    2. Convert '.' between digits to 'p'.
-    3. Convert '<not letter>v<digit>' -> '<not letter><digit>'
-    4. Remove all non-alphanumeric characters except between digits.
+    2. Strips '.near' and '.ai' extensions.
+    3. Convert '.' between digits to 'p'.
+    4. Convert '<not letter>v<digit>' -> '<not letter><digit>'
+    5. Remove all non-alphanumeric characters except between digits.
         Use '_' between digits.
-    5. Convert 'metallama' -> 'llama'.
+    6. Convert 'metallama' -> 'llama'.
 
     e.g. "llama-3.1-70b-instruct" -> "llama3p1_70binstruct"
     """
     # Convert to lowercase
     name = name.lower()
+    # Strip .near extension if present
+    if name.endswith(".near"):
+        name = name[:-5]  # Remove last 5 characters ('.near')
+    # Strip .ai extension if present
+    if name.endswith(".ai"):
+        name = name[:-3]  # Remove last 3 characters ('.ai')
     # Convert '.' between digits to 'p'
     name = re.sub(r"(\d)\.(\d)", r"\1p\2", name)
     # Convert '<digit>v<digit>' -> '<digit>_<digit>'

--- a/nearai/shared/tests/test_naming.py
+++ b/nearai/shared/tests/test_naming.py
@@ -61,6 +61,12 @@ class TestGetCanonicalName(unittest.TestCase):
         )
         self.assertEqual(get_canonical_name("llama-3.1-405b-instruct"), get_canonical_name("llama-v3p1-405b-instruct"))
 
+    def test_extensions(self):  # noqa: D102
+        self.assertEqual(get_canonical_name("john_smith.near"), get_canonical_name("john_smith"))
+        self.assertEqual(get_canonical_name("john_smith.ai"), get_canonical_name("john_smith"))
+        self.assertEqual(get_canonical_name("john_smith.alpha"), get_canonical_name("john_smith.alpha"))
+        self.assertEqual(get_canonical_name("john_smith.a"), get_canonical_name("john_smith.a"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/nearai/shared/tests/test_naming.py
+++ b/nearai/shared/tests/test_naming.py
@@ -63,9 +63,10 @@ class TestGetCanonicalName(unittest.TestCase):
 
     def test_extensions(self):  # noqa: D102
         self.assertEqual(get_canonical_name("john_smith.near"), get_canonical_name("john_smith"))
-        self.assertEqual(get_canonical_name("john_smith.ai"), get_canonical_name("john_smith.ai"))
-        self.assertEqual(get_canonical_name("john_smith.alpha"), get_canonical_name("john_smith.alpha"))
-        self.assertEqual(get_canonical_name("john_smith.a"), get_canonical_name("john_smith.a"))
+        self.assertNotEqual(get_canonical_name("john_smith.ai"), get_canonical_name("john_smith"))
+        self.assertNotEqual(get_canonical_name("john_smith.alpha"), get_canonical_name("john_smith"))
+        self.assertNotEqual(get_canonical_name("john_smith.a"), get_canonical_name("john_smith"))
+        self.assertNotEqual(get_canonical_name("john_smith.a"), get_canonical_name("john_smith.ai"))
 
 
 if __name__ == "__main__":

--- a/nearai/shared/tests/test_naming.py
+++ b/nearai/shared/tests/test_naming.py
@@ -63,7 +63,7 @@ class TestGetCanonicalName(unittest.TestCase):
 
     def test_extensions(self):  # noqa: D102
         self.assertEqual(get_canonical_name("john_smith.near"), get_canonical_name("john_smith"))
-        self.assertEqual(get_canonical_name("john_smith.ai"), get_canonical_name("john_smith"))
+        self.assertEqual(get_canonical_name("john_smith.ai"), get_canonical_name("john_smith.ai"))
         self.assertEqual(get_canonical_name("john_smith.alpha"), get_canonical_name("john_smith.alpha"))
         self.assertEqual(get_canonical_name("john_smith.a"), get_canonical_name("john_smith.a"))
 


### PR DESCRIPTION
So that:
1. model `jones.near/model` matches with fireworks model `jones/model`
2. check for username <-> organization collisions. Will prevent creation of `jones/model` entry if `jones.near/model` exists.