### PR TITLE
fix: No module named 'rich'

### DIFF
--- a/aws_runner/frameworks/requirements-minimal.txt
+++ b/aws_runner/frameworks/requirements-minimal.txt
@@ -18,3 +18,4 @@ tweepy >= 4.14.0
 tenacity == 9.0.0
 mcp
 ddtrace == 2.21.0
+rich == 13.9.4

--- a/aws_runner/frameworks/requirements-standard.txt
+++ b/aws_runner/frameworks/requirements-standard.txt
@@ -30,3 +30,4 @@ web3 >= 7.8.0
 eth-account >= 0.13.5
 numpy >= 1.21.0
 ddtrace == 2.21.0
+rich == 13.9.4


### PR DESCRIPTION
I see an error Exception: Request failed with status code 502: {"errorMessage": "Unable to import module 'datadog_lambda.handler': No module named 'rich'", "errorType": "Runtime.ImportModuleError", "requestId": "", "stackTrace": []} on a local runner. I can add a missing dependency for runners with the rich package, but do we really need it?