### PR TITLE
fix: move rich display logic to cli_helpers.py

### DIFF
--- a/nearai/cli.py
+++ b/nearai/cli.py
@@ -25,6 +25,7 @@ from nearai.agents.local_runner import LocalRunner
 from nearai.cli_helpers import (
     assert_user_auth,
     display_agents_in_columns,
+    display_version_check,
     has_pending_input,
     load_and_validate_metadata,
 )
@@ -338,10 +339,8 @@ class RegistryCli:
             )
             return None
 
-        if exists:
-            console.print(f"\n❌ [yellow]Version [cyan]{version}[/cyan] already exists.[/yellow]")
-        else:
-            console.print(f"\n✅ [green]Version [cyan]{version}[/cyan] is available.[/green]")
+        # Display the version check result
+        display_version_check(namespace, name, version, exists)
 
         bump_requested = bump or minor_bump or major_bump
 

--- a/nearai/cli_helpers.py
+++ b/nearai/cli_helpers.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from rich.console import Console
 from rich.table import Table
+from rich.text import Text
 
 from nearai.registry import validate_version
 
@@ -116,3 +117,33 @@ def assert_user_auth() -> None:
     if CONFIG.auth is None:
         print("Please login with `nearai login` first")
         exit(1)
+
+
+def display_version_check(namespace: str, name: str, version: str, exists: bool) -> None:
+    """Display formatted message about version existence check.
+
+    Args:
+    ----
+        namespace: The namespace
+        name: The agent name
+        version: The version being checked
+        exists: Whether the version exists
+
+    """
+    console = Console()
+    console.print(
+        Text.assemble(
+            ("\n🔎 Checking if version ", "white"),
+            (f"{version}", "green bold"),
+            (" exists for ", "white"),
+            (f"{name} ", "blue bold"),
+            ("in the registry under ", "white"),
+            (f"{namespace}", "cyan bold"),
+            ("...", "white"),
+        )
+    )
+
+    if exists:
+        console.print(f"\n❌ [yellow]Version [cyan]{version}[/cyan] already exists.[/yellow]")
+    else:
+        console.print(f"\n✅ [green]Version [cyan]{version}[/cyan] is available.[/green]")

--- a/nearai/registry.py
+++ b/nearai/registry.py
@@ -4,8 +4,6 @@ from shutil import copyfileobj
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from packaging.version import InvalidVersion, Version
-from rich.console import Console
-from rich.text import Text
 from tqdm import tqdm
 
 # Note: We should import nearai.config on this file to make sure the method setup_api_client is called at least once
@@ -476,18 +474,6 @@ def check_version_exists(namespace: str, name: str, version: str) -> Tuple[bool,
     """
     entry_location = f"{namespace}/{name}/{version}"
     try:
-        console = Console()
-        console.print(
-            Text.assemble(
-                ("\n🔎 Checking if version ", "white"),
-                (f"{version}", "green bold"),
-                (" exists for ", "white"),
-                (f"{name} ", "blue bold"),
-                ("in the registry under ", "white"),
-                (f"{namespace}", "cyan bold"),
-                ("...", "white"),
-            )
-        )
         existing_entry = registry.info(parse_location(entry_location))
 
         if existing_entry:

--- a/uv.lock
+++ b/uv.lock
@@ -2260,7 +2260,7 @@ wheels = [
 
 [[package]]
 name = "nearai"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Moves `Rich` display logic to `cli_helpers.py` to resolve import errors w/ local runners.