### PR TITLE
Agent Interactive: Return to one line mode and give 'multiline' option

### DIFF
--- a/nearai/cli.py
+++ b/nearai/cli.py
@@ -759,9 +759,8 @@ class AgentCli:
         last_message_id = None
         print(f"\n=== Starting interactive session with agent: {agent_id} ===")
         print("")
-        print("On Linux/macOS: To submit, press Ctrl+D at the beginning of a new line after your prompt")
-        print("On Windows: Press Ctrl+Z followed by Enter")
         print("Type 'exit' to end the session")
+        print("Type 'multiline' to enter multiline mode")
         print("")
 
         metadata = get_metadata(agent_path, local)
@@ -772,20 +771,38 @@ class AgentCli:
         if description:
             print(description)
 
+        multiline = False
+
+        def print_multiline_prompt():
+            print("On Linux/macOS: To submit, press Ctrl+D at the beginning of a new line after your prompt")
+            print("On Windows: Press Ctrl+Z followed by Enter")
+
         while True:
             first_line = input("> ")
             if first_line.lower() == "exit":
                 break
+            if not multiline and first_line.lower() == "multiline":
+                multiline = True
+                print_multiline_prompt()
+                continue
             lines = [first_line]
-            try:
-                pending_input_on_prev_line = False
-                while True:
-                    pending_input_on_this_line = has_pending_input()
-                    line = input("") if (pending_input_on_prev_line or pending_input_on_this_line) else input("> ")
-                    lines.append(line)
-                    pending_input_on_prev_line = pending_input_on_this_line
-            except EOFError:
-                print("")
+            pending_input_on_this_line = has_pending_input()
+            if multiline or pending_input_on_this_line:
+                try:
+                    pending_input_on_prev_line = True
+                    while True:
+                        pending_input_on_this_line = has_pending_input()
+                        if pending_input_on_prev_line or pending_input_on_this_line:
+                            line = input("")
+                        else:
+                            if not multiline:
+                                multiline = True
+                                print_multiline_prompt()
+                            line = input("> ")
+                        lines.append(line)
+                        pending_input_on_prev_line = pending_input_on_this_line
+                except EOFError:
+                    print("")
 
             new_message = "\n".join(lines)
 

--- a/nearai/cli.py
+++ b/nearai/cli.py
@@ -786,6 +786,11 @@ class AgentCli:
                 print_multiline_prompt()
                 continue
             lines = [first_line]
+
+            # NOTE: the code below tries to catch copy-paste by calling has_pending_input().
+            # This is OS-specific functionality and has been tested on Unix/Linux/Mac:
+            # 1. Works well with blocks of text of 3 lines and more.
+            # 2. Alas, does not trigger with text of 2 lines or less.
             pending_input_on_this_line = has_pending_input()
             if multiline or pending_input_on_this_line:
                 try:

--- a/nearai/cli.py
+++ b/nearai/cli.py
@@ -789,7 +789,7 @@ class AgentCli:
             pending_input_on_this_line = has_pending_input()
             if multiline or pending_input_on_this_line:
                 try:
-                    pending_input_on_prev_line = True
+                    pending_input_on_prev_line = pending_input_on_this_line
                     while True:
                         pending_input_on_this_line = has_pending_input()
                         if pending_input_on_prev_line or pending_input_on_this_line:


### PR DESCRIPTION
Also, copy-paste automatically switches to 'multiline' mode. However, it only works with 3 lines or more. I could not figure out how to make it work for 2 lines.