### PR TITLE
Fix evaluation model_provider() bug

### DIFF
--- a/nearai/solvers/__init__.py
+++ b/nearai/solvers/__init__.py
@@ -188,7 +188,7 @@ class SolverStrategy(ABC, metaclass=SolverStrategyMeta):
         if self.provider != "":
             return self.provider
         if self.agent != "":
-            agent_obj = Agent.load_agent(self.agent, self.client_config)
+            agent_obj = Agent.load_agent(self.agent, self.client_config, local=True)
             return agent_obj.model_provider
         return ""
 


### PR DESCRIPTION
Benchmarks are run locally, and evaluation creation step crashes when trying to load an agent.