### PR TITLE
Fixes an issue where get_namespace fails if local_path is not relative to registry_folder

### DIFF
--- a/nearai/agents/environment.py
+++ b/nearai/agents/environment.py
@@ -564,7 +564,11 @@ class Environment(object):
 
         def save_agent_data(key, data: Dict[str, Any]):
             """Save agent data."""
-            return client.save_agent_data(key, data)
+            try:
+                return client.save_agent_data(key, data)
+            except Exception as ex:
+                self.add_system_log(f"Error saving agent data by key {key}: {ex}", logging.ERROR)
+                return None
 
         self.save_agent_data = save_agent_data
 
@@ -578,7 +582,11 @@ class Environment(object):
             """Get agent data by key."""
             namespace = self.get_primary_agent().namespace
             name = self.get_primary_agent().name
-            result = client.get_agent_data_by_key(key)
+            try:
+                result = client.get_agent_data_by_key(key)
+            except Exception as ex:
+                self.add_system_log(f"Error getting agent data by key {key}: {ex}", logging.ERROR)
+                result = None
             return (
                 result
                 if result

--- a/nearai/registry.py
+++ b/nearai/registry.py
@@ -53,15 +53,24 @@ def get_namespace(local_path: Path) -> str:
     try:
         # Check if the path matches the expected structure
         relative_path = local_path.relative_to(registry_folder)
+
+    except ValueError:
+        # If local_path is not relative to registry_folder, try resolving it to an absolute path
+        local_path = local_path.resolve()
+        try:
+            # Retry checking if the now absolute path is within registry_folder
+            relative_path = local_path.relative_to(registry_folder)
+        except ValueError:
+            relative_path = None
+            pass
+
+    if relative_path:
         parts = relative_path.parts
 
         # If the path has 3 parts (namespace, item_name, version),
         # return the first part as the namespace
         if len(parts) == 3:
             return str(parts[0])
-    except ValueError:
-        # relative_to() raises ValueError if local_path is not relative to registry_folder
-        pass
 
     # If we couldn't extract a namespace from the path, return the default
     if CONFIG.auth is None:


### PR DESCRIPTION
Fixes an issue where get_namespace fails if local_path is not relative to registry_folder. Now, if relative_to() raises a ValueError, the function resolves local_path to an absolute path and retries. If the path is still not within registry_folder, it safely returns None instead of failing.

How to reproduce the bug:

```
nearai registry download near-ai-agents.near/assistant/0.0.5
cd ~/.nearai/registry/near-ai-agents.near/assistant/0.0.5
nearai agent interactive . --local
```


![Screenshot 2025-03-14 at 11 29 35 AM](https://github.com/user-attachments/assets/abc3f085-c165-423d-969f-7a344c52d4ce)