### PR TITLE
fix: 403 errors for agent_data methods in local mode

### DIFF
--- a/nearai/agents/environment.py
+++ b/nearai/agents/environment.py
@@ -567,7 +567,7 @@ class Environment(object):
             try:
                 return client.save_agent_data(key, data)
             except Exception as ex:
-                self.add_system_log(f"Error saving agent data: {ex}", logging.ERROR)
+                self.add_system_log(f"Error saving agent data by key {key}: {ex}", logging.ERROR)
                 return None
 
         self.save_agent_data = save_agent_data
@@ -584,8 +584,8 @@ class Environment(object):
             name = self.get_primary_agent().name
             try:
                 result = client.get_agent_data_by_key(key)
-            except Exception as e:
-                self.add_system_log(f"Error getting agent data by key: {e}", logging.ERROR)
+            except Exception as ex:
+                self.add_system_log(f"Error getting agent data by key {key}: {ex}", logging.ERROR)
                 result = None
             return (
                 result

--- a/nearai/agents/environment.py
+++ b/nearai/agents/environment.py
@@ -564,7 +564,11 @@ class Environment(object):
 
         def save_agent_data(key, data: Dict[str, Any]):
             """Save agent data."""
-            return client.save_agent_data(key, data)
+            try:
+                return client.save_agent_data(key, data)
+            except Exception as ex:
+                self.add_system_log(f"Error saving agent data: {ex}", logging.ERROR)
+                return None
 
         self.save_agent_data = save_agent_data
 
@@ -578,7 +582,11 @@ class Environment(object):
             """Get agent data by key."""
             namespace = self.get_primary_agent().namespace
             name = self.get_primary_agent().name
-            result = client.get_agent_data_by_key(key)
+            try:
+                result = client.get_agent_data_by_key(key)
+            except Exception as e:
+                self.add_system_log(f"Error getting agent data by key: {e}", logging.ERROR)
+                result = None
             return (
                 result
                 if result


### PR DESCRIPTION
Handles cases where agent data storage and retrieval fail due to authorization errors - Not authorized to store data for this agent). Instead of raising exceptions, the environment now logs the error and proceeds without persistent agent data. This allows agents to function without memory when running locally, rather than through the hub.

(e.g., ![Screenshot 2025-03-14 at 11 58 01 AM](https://github.com/user-attachments/assets/9355bf98-14c0-4099-aa82-c8ee14613baf)