### PR TITLE
fix: Handle Redirects in async_fetch_json

### DIFF
--- a/hub/api/v1/neardata.py
+++ b/hub/api/v1/neardata.py
@@ -29,7 +29,7 @@ near_scheduler = AsyncIOScheduler()
 
 
 async def async_fetch_json(url: str) -> Any:
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(follow_redirects=True) as client:
         response = await client.get(url)
         if response.status_code == 200:
             return response.json()

--- a/hub/tasks/near_events.py
+++ b/hub/tasks/near_events.py
@@ -53,7 +53,7 @@ async def async_fetch_json(url: str) -> Any:
         headers["Authorization"] = f"Bearer {api_key}"
 
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
             response = await client.get(url, headers=headers, timeout=3)
             response.raise_for_status()
             if response.status_code == 200:


### PR DESCRIPTION
The function fails on HTTP 302 because httpx.AsyncClient doesn’t follow redirects by default.