### PR TITLE
Clean model name for livebench benchmark

### DIFF
--- a/nearai/solvers/livebench_solver.py
+++ b/nearai/solvers/livebench_solver.py
@@ -2,6 +2,7 @@ import csv
 import glob
 import json
 import os
+import re
 import subprocess
 import time
 from typing import Any, Dict, List, Tuple, Union
@@ -91,8 +92,8 @@ class LiveBenchSolverStrategy(SolverStrategy):
                 name += f"_with_model_{self.model_name}"
         else:
             name = self.model_name
-        assert "/" not in name
-        return name.lower()
+        clean_name = re.sub(r"[^a-zA-Z0-9_\-.]", "_", name)
+        return clean_name.lower()
 
     @SolverStrategyClassProperty
     def scoring_method(self) -> SolverScoringMethod:  # noqa: D102


### PR DESCRIPTION
Slashes in model name are valid, but the result `live_bench.evaluated_entry_name` is used as a folder name. So, this PR cleans the characters that are not ok for folder names.