### PR TITLE
fix: update cli install instructions

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,10 +7,40 @@ NEAR AI CLI allows you to [create and deploy agents](./agents/quickstart.md), [t
 ## Installing NEAR AI CLI
 
 !!! warning
-    Requires Python version **`3.11`** _(Currently does not work with `3.12` or `3.13`)_
+    Requires Python version **`3.9 - 3.11`** _(Currently does not work with `3.12` or `3.13`)_
 
-!!! tip
-     Although not required, this project uses [uv](https://docs.astral.sh/uv/) for Python package management and it is suggested that you use it as well if you would like to make contributions to this project.
+!!! abstract "Python Version Management"
+
+    If you do not have Python, or your version is not compatible, we recommend using a version management tool as they allow you to easily install and switch between python versions. 
+    
+    Here are a few options to choose from:
+    
+    - [uv](https://docs.astral.sh/uv/) - Fast Python package manager _(Preferred tool by `nearai` core contributors)_
+    - [pyenv](https://github.com/pyenv/pyenv) - Simple Python version management tool
+    - [miniconda](https://docs.anaconda.com/miniconda/install/) - Miniature installation of Anaconda Distribution 
+
+    === "uv"
+
+        ```bash
+        uv venv --python 3.11
+        source .venv/bin/activate
+        ```
+    
+    === "pyenv"
+
+        ```bash
+        pyenv install 3.11
+        pyenv local 3.11 # or use global
+        ```
+
+    === "conda"
+
+        ``` bash
+        conda create -n myenv python=3.11
+        conda activate myenv
+        ```
+
+---
 
 === "pip"
 
@@ -20,13 +50,75 @@ NEAR AI CLI allows you to [create and deploy agents](./agents/quickstart.md), [t
 
 === "local"
 
+    Clone project:
+    
     ``` bash
     git clone git@github.com:nearai/nearai.git
     cd nearai
-    ./install.sh
     ```
+    
+    Install `nearai`:
+
+    === "uv"
+
+        Download, create, and activate a virtual Python 3.11 environment:
+
+        ```bash
+        uv venv --python 3.11
+        source .venv/bin/activate
+        ```
+        
+        Install `nearai` from repo:
+        
+        ```bash
+        pip install -e .
+        ```
+
+    === "conda"
+
+        Download, create, and activate a virtual Python `3.11` environment:
+        
+        ```bash
+        conda create -n nearai python=3.11
+        conda activate nearai
+        ```
+
+        Install `nearai`:
+        ```bash
+        pip install -e .
+        ```
+
+    === "pyenv" 
+
+        If needed, install Python 3.11 with `pyenv`:
+
+        ```bash
+        pyenv install 3.11
+        ```
+
+        Set local version to `3.11`:
+        
+        ```bash
+        pyenv local 3.11
+        ```
+        
+        Create and activate a virtual environment:
+        
+        ```bash
+        python -m venv .venv
+        source .venv/bin/activate
+        ```
+
+        Install `nearai` from local repo:
+
+        ```bash
+        pip install --upgrade pip
+        pip install -e .
+        ```
 
 ---
+
+
 
 ## Login to NEAR AI
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,12 +4,12 @@ NEAR AI CLI allows you to [create and deploy agents](./agents/quickstart.md), [t
 
 ---
 
-### Pre-Requisite: Python 3.9 - 3.11
+### Requirements
 
-To use NEAR AI CLI, you need to have Python `3.9 - 3.11` installed on your machine. Currently the CLI does not work with Python `3.12` or `3.13`.
+- Python 3.9 - 3.11 **(3.12 - 3.13 is NOT supported)**
+- [NEAR Account](#login-to-near-ai)
 
-We recommend you to create a virtual environment to avoid conflicts with other Python packages.
-
+Additionally, we recommend creating a virtual environment to avoid conflicts with other Python packages.
 
 === "uv"
 
@@ -62,7 +62,7 @@ We recommend you to create a virtual environment to avoid conflicts with other P
 
 
 !!! warning "Python version"
-    NEARAI CLI requires python **`3.9 - 3.11`**, we recommend you to [create a virtual environment](#pre-requisite-python-39---311) to avoid conflicts with other Python packages.
+    NEAR AI requires python **`3.9 - 3.11`**. We recommend you to [create a virtual environment](#requirements) to avoid conflicts with other Python packages or globally installing dependencies if installing locally w/ repo. 
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,107 +4,67 @@ NEAR AI CLI allows you to [create and deploy agents](./agents/quickstart.md), [t
 
 ---
 
-!!! warning
-    Requires Python version **`3.9 - 3.11`** _(Currently does not work with `3.12` or `3.13`)_
+### Pre-Requisite: Python 3.9 - 3.11
 
-!!! abstract "Python Version Management"
+To use NEAR AI CLI, you need to have Python `3.9 - 3.11` installed on your machine. Currently the CLI does not work with Python `3.12` or `3.13`.
 
-    New to Python or don't have a compatible version? Try using a version management tool as they allow you to easily install and switch between Python versions. 
-    
-    Here are some popular options:
-    
-    - [uv](https://docs.astral.sh/uv/) - Fast Python package manager _(Preferred tool by `nearai` core contributors)_
-    - [pyenv](https://github.com/pyenv/pyenv) - Simple Python version management tool
-    - [miniconda](https://docs.anaconda.com/miniconda/install/) - Miniature installation of Anaconda Distribution 
+We recommend you to create a virtual environment to avoid conflicts with other Python packages.
+
+
+=== "uv"
+
+    ```bash
+    # Create a virtual environment with python 3.11
+    uv venv --python 3.11
+    source .venv/bin/activate
+    ```
+
+=== "conda"
+
+    ```bash
+    # Create a virtual environment with python 3.11
+    conda create -n nearai python=3.11
+    conda activate nearai
+    ```
+
+=== "pyenv" 
+
+    ```bash
+    # Install python 3.11
+    pyenv install 3.11
+    pyenv local 3.11
+
+    # Create a virtual environment
+    python -m venv .venv
+    source .venv/bin/activate
+    ```
+
+---
 
 ## Installing NEAR AI CLI
 
 === "pip"
 
     ``` bash
-    python3 -m pip install nearai
+    pip install nearai  # OR: python3 -m pip install nearai
     ```
 
 === "local"
 
-    Clone project:
-    
     ``` bash
+    # Clone the repository:
     git clone git@github.com:nearai/nearai.git
     cd nearai
+
+    # Install dependencies:
+    pip install -e .  # OR: python3 -m pip install -e .
     ```
-    
-    Install `nearai`:
 
-    === "Install Script"
 
-        ```bash
-        ./install.sh
-        ```
-
-        This script uses Python3's built in virtual environment creator `venv`.
-        
-        **Please ensure you are using Python `3.9-3.11` before running.**
-
-    === "uv"
-
-        Download, create, and activate a virtual Python `3.11` environment:
-
-        ```bash
-        uv venv --python 3.11
-        source .venv/bin/activate
-        ```
-        
-        Install `nearai` from repo:
-        
-        ```bash
-        pip install -e .
-        ```
-
-    === "conda"
-
-        Download, create, and activate a virtual Python `3.11` environment:
-        
-        ```bash
-        conda create -n nearai python=3.11
-        conda activate nearai
-        ```
-
-        Install `nearai` from local repo:
-        ```bash
-        pip install -e .
-        ```
-
-    === "pyenv" 
-
-        If needed, install Python `3.11` with `pyenv`:
-
-        ```bash
-        pyenv install 3.11
-        ```
-
-        Set local version to `3.11`:
-        
-        ```bash
-        pyenv local 3.11
-        ```
-        
-        Create and activate a virtual environment:
-        
-        ```bash
-        python -m venv .venv
-        source .venv/bin/activate
-        ```
-
-        Install `nearai` from local repo:
-
-        ```bash
-        pip install --upgrade pip
-        pip install -e .
-        ```
+!!! warning "Python version"
+    NEARAI CLI requires python **`3.9 - 3.11`**, we recommend you to [create a virtual environment](#pre-requisite-python-39---311) to avoid conflicts with other Python packages.
 
 ---
-
 
 
 ## Login to NEAR AI

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,43 +4,20 @@ NEAR AI CLI allows you to [create and deploy agents](./agents/quickstart.md), [t
 
 ---
 
-## Installing NEAR AI CLI
-
 !!! warning
     Requires Python version **`3.9 - 3.11`** _(Currently does not work with `3.12` or `3.13`)_
 
 !!! abstract "Python Version Management"
 
-    If you do not have Python, or your version is not compatible, we recommend using a version management tool as they allow you to easily install and switch between python versions. 
+    New to Python or don't have a compatible version? Try using a version management tool as they allow you to easily install and switch between Python versions. 
     
-    Here are a few options to choose from:
+    Here are some popular options:
     
     - [uv](https://docs.astral.sh/uv/) - Fast Python package manager _(Preferred tool by `nearai` core contributors)_
     - [pyenv](https://github.com/pyenv/pyenv) - Simple Python version management tool
     - [miniconda](https://docs.anaconda.com/miniconda/install/) - Miniature installation of Anaconda Distribution 
 
-    === "uv"
-
-        ```bash
-        uv venv --python 3.11
-        source .venv/bin/activate
-        ```
-    
-    === "pyenv"
-
-        ```bash
-        pyenv install 3.11
-        pyenv local 3.11 # or use global
-        ```
-
-    === "conda"
-
-        ``` bash
-        conda create -n myenv python=3.11
-        conda activate myenv
-        ```
-
----
+## Installing NEAR AI CLI
 
 === "pip"
 
@@ -59,9 +36,19 @@ NEAR AI CLI allows you to [create and deploy agents](./agents/quickstart.md), [t
     
     Install `nearai`:
 
+    === "Install Script"
+
+        ```bash
+        ./install.sh
+        ```
+
+        This script uses Python3's built in virtual environment creator `venv`.
+        
+        **Please ensure you are using Python `3.9-3.11` before running.**
+
     === "uv"
 
-        Download, create, and activate a virtual Python 3.11 environment:
+        Download, create, and activate a virtual Python `3.11` environment:
 
         ```bash
         uv venv --python 3.11
@@ -83,14 +70,14 @@ NEAR AI CLI allows you to [create and deploy agents](./agents/quickstart.md), [t
         conda activate nearai
         ```
 
-        Install `nearai`:
+        Install `nearai` from local repo:
         ```bash
         pip install -e .
         ```
 
     === "pyenv" 
 
-        If needed, install Python 3.11 with `pyenv`:
+        If needed, install Python `3.11` with `pyenv`:
 
         ```bash
         pyenv install 3.11

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,16 +1,16 @@
 # NEAR AI CLI
 
-The NEAR AI CLI allows you to interact with NEAR AI's services to [create agents](./agents/quickstart.md) or [train and test models](./models/home.md). Let's quickly review how to install it and login with your NEAR account.
-
-!!! tip
-    Do you want to build an agent? Install the CLI, login, and then check our [**Agent Quickstart Guide**](./agents/quickstart.md).
-
-!!! info
-    Remember that you can use NEAR AI from the [Web Hub](https://hub.near.ai), the NEAR AI CLI is targeted at developers who want to build their own agents or train models on NEAR AI.
+NEAR AI CLI allows you to [create and deploy agents](./agents/quickstart.md), [train and test models](./models/home.md), and more!
 
 ---
 
 ## Installing NEAR AI CLI
+
+!!! warning
+    Requires Python version **`3.11`** _(Currently does not work with `3.12` or `3.13`)_
+
+!!! tip
+     Although not required, this project uses [uv](https://docs.astral.sh/uv/) for Python package management and it is suggested that you use it as well if you would like to make contributions to this project.
 
 === "pip"
 
@@ -23,27 +23,8 @@ The NEAR AI CLI allows you to interact with NEAR AI's services to [create agents
     ``` bash
     git clone git@github.com:nearai/nearai.git
     cd nearai
-    pip install -e .
+    ./install.sh
     ```
-
-??? abstract "Python Version"
-
-    If you do not have python, or your version is not compatible, we recommend that you use [miniconda](https://docs.anaconda.com/miniconda/install/) or [pyenv](https://github.com/pyenv/pyenv)
-    to manage your installations, as they both allow you to easily switch between python versions.
-
-    === "pyenv"
-
-        ``` bash
-        pyenv install 3.11
-        pyenv local 3.11 # or use global
-        ```
-
-    === "conda"
-
-        ``` bash
-        conda create -n myenv python=3.11
-        conda activate myenv
-        ```
 
 ---
 
@@ -76,7 +57,7 @@ After successfully logging in, you will see a confirmation screen. Close it and 
 
 ![alt text](./assets/agents/quickstart-login.png)
 
-??? tip Other Login Methods
+??? tip "Other Login Methods"
 
     If you have already logged in on `near-cli`, you know your account's private key, or you have the credentials on another device, you can use the following commands to login:
 
@@ -95,4 +76,4 @@ After successfully logging in, you will see a confirmation screen. Close it and 
 
 ## Next Steps
 
-That's it! You're now ready to create your first agent. Head over to the [Agents Guide](./agents/quickstart.md) to get started.
+That's it! Head over to the [Agent Quickstart](./agents/quickstart.md) to get started creating your first agent! 🚀


### PR DESCRIPTION
Many users at the recent hackathon reported difficulties installing NEAR CLI as it was not apparent they needed Python 3.11 as mentioned in #1051. 

 This PR adds a more prominent callout for the `3.11` requirement as well as suggesting `uv` as they will need this if they intend to contribute to the codebase or docs.

(Also removed the info callout to NEAR AI hub w/ broken link) I don't feel this is necessary to call out.