### PR TITLE
Bernardomafra/nea 80 adapt near tool registry to handle mcp format

### DIFF
--- a/nearai/agents/models/tool_definition.py
+++ b/nearai/agents/models/tool_definition.py
@@ -12,6 +12,6 @@ class MCPTool(BaseModel):
     """The name of the tool."""
     description: str | None = None
     """A human-readable description of the tool."""
-    inputSchema: dict[str, Any] # noqa: N815
+    inputSchema: dict[str, Any]  # noqa: N815
     """A JSON Schema object defining the expected parameters for the tool."""
     model_config = ConfigDict(extra="allow")

--- a/nearai/agents/models/tool_definition.py
+++ b/nearai/agents/models/tool_definition.py
@@ -1,0 +1,45 @@
+from typing import Dict, List, Literal
+from pydantic import BaseModel, ConfigDict
+
+class ToolParameterProperty(BaseModel):
+    """Properties for a tool parameter."""
+    type: str
+    description: str
+    enum: List[str] | None = None
+
+    model_config = ConfigDict(
+        extra='forbid',
+        validate_assignment=True
+    )
+
+class ToolParameters(BaseModel):
+    """Parameters configuration for a tool."""
+    type: Literal["object"]
+    properties: Dict[str, ToolParameterProperty]
+    required: List[str]
+
+    model_config = ConfigDict(
+        extra='forbid',
+        validate_assignment=True
+    )
+
+class ToolFunction(BaseModel):
+    """Function definition for a tool."""
+    name: str
+    description: str
+    parameters: ToolParameters
+
+    model_config = ConfigDict(
+        extra='forbid',
+        validate_assignment=True
+    )
+
+class ToolDefinition(BaseModel):
+    """Complete tool definition."""
+    type: Literal["function"]
+    function: ToolFunction
+
+    model_config = ConfigDict(
+        extra='forbid',
+        validate_assignment=True
+    )

--- a/nearai/agents/models/tool_definition.py
+++ b/nearai/agents/models/tool_definition.py
@@ -1,45 +1,12 @@
-from typing import Dict, List, Literal
+from typing import Any
 from pydantic import BaseModel, ConfigDict
+class MCPTool(BaseModel):
+    """Definition for a tool the client can call."""
 
-class ToolParameterProperty(BaseModel):
-    """Properties for a tool parameter."""
-    type: str
-    description: str
-    enum: List[str] | None = None
-
-    model_config = ConfigDict(
-        extra='forbid',
-        validate_assignment=True
-    )
-
-class ToolParameters(BaseModel):
-    """Parameters configuration for a tool."""
-    type: Literal["object"]
-    properties: Dict[str, ToolParameterProperty]
-    required: List[str]
-
-    model_config = ConfigDict(
-        extra='forbid',
-        validate_assignment=True
-    )
-
-class ToolFunction(BaseModel):
-    """Function definition for a tool."""
     name: str
-    description: str
-    parameters: ToolParameters
-
-    model_config = ConfigDict(
-        extra='forbid',
-        validate_assignment=True
-    )
-
-class ToolDefinition(BaseModel):
-    """Complete tool definition."""
-    type: Literal["function"]
-    function: ToolFunction
-
-    model_config = ConfigDict(
-        extra='forbid',
-        validate_assignment=True
-    )
+    """The name of the tool."""
+    description: str | None = None
+    """A human-readable description of the tool."""
+    inputSchema: dict[str, Any]
+    """A JSON Schema object defining the expected parameters for the tool."""
+    model_config = ConfigDict(extra="allow")

--- a/nearai/agents/models/tool_definition.py
+++ b/nearai/agents/models/tool_definition.py
@@ -1,6 +1,8 @@
 from typing import Any
 from pydantic import BaseModel, ConfigDict
 
+# TODO: We should import the mcp Tool types from the MCP package
+# This is temporary since we have some dependencies conflicting with the MCP package
 class MCPTool(BaseModel):
     """Definition for a tool the client can call."""
 

--- a/nearai/agents/models/tool_definition.py
+++ b/nearai/agents/models/tool_definition.py
@@ -1,5 +1,6 @@
 from typing import Any
 from pydantic import BaseModel, ConfigDict
+
 class MCPTool(BaseModel):
     """Definition for a tool the client can call."""
 

--- a/nearai/agents/models/tool_definition.py
+++ b/nearai/agents/models/tool_definition.py
@@ -10,7 +10,7 @@ class MCPTool(BaseModel):
 
     name: str
     """The name of the tool."""
-    description: str | None = None
+    description: str = ""
     """A human-readable description of the tool."""
     inputSchema: dict[str, Any]  # noqa: N815
     """A JSON Schema object defining the expected parameters for the tool."""

--- a/nearai/agents/models/tool_definition.py
+++ b/nearai/agents/models/tool_definition.py
@@ -1,5 +1,7 @@
 from typing import Any
+
 from pydantic import BaseModel, ConfigDict
+
 
 # TODO: We should import the mcp Tool types from the MCP package
 # This is temporary since we have some dependencies conflicting with the MCP package
@@ -10,6 +12,6 @@ class MCPTool(BaseModel):
     """The name of the tool."""
     description: str | None = None
     """A human-readable description of the tool."""
-    inputSchema: dict[str, Any]
+    inputSchema: dict[str, Any] # noqa: N815
     """A JSON Schema object defining the expected parameters for the tool."""
     model_config = ConfigDict(extra="allow")

--- a/nearai/agents/tool_json_helper.py
+++ b/nearai/agents/tool_json_helper.py
@@ -1,8 +1,6 @@
 import json
 import re
 
-from nearai.agents.models.tool_definition import ToolDefinition, ToolFunction, ToolParameterProperty, ToolParameters
-
 def _ending_transform(x):
     if x.endswith('}"') or x.endswith("}}"):
         return json.loads(x[:-1])
@@ -71,30 +69,3 @@ def parse_json_args_based_on_signature(signature: dict, args: str):
         parameter_values[param] = raw_value
     return parameter_values
 
-
-def parse_tool_definition_based_on_mcp_tool(mcp_tool) -> ToolDefinition:
-    """Parses an MCP tool into a registry tool definition."""
-    tool_parameters = ToolParameters(
-        type="object",
-        properties={},
-        required=[],
-    )
-    for param_name, param_schema in mcp_tool.inputSchema.get("properties", {}).items():
-        param_property = ToolParameterProperty(
-            type=param_schema.get("type", "string"),
-            description=param_schema.get("description", ""),
-        )
-
-        if param_schema.get("enum", None):
-            param_property.enum = param_schema.get("enum", None)
-
-        tool_parameters.properties[param_name] = param_property
-
-    return ToolDefinition(
-        type="function",
-        function=ToolFunction(
-            name=mcp_tool.name,
-            description=mcp_tool.description,
-            parameters=tool_parameters
-        )
-    )

--- a/nearai/agents/tool_json_helper.py
+++ b/nearai/agents/tool_json_helper.py
@@ -1,12 +1,12 @@
 import json
 import re
 
+
 def _ending_transform(x):
     if x.endswith('}"') or x.endswith("}}"):
         return json.loads(x[:-1])
     else:
         raise json.JSONDecodeError("Try next transform", x, len(x))
-
 
 def parse_json_args(signature: dict, args: str):
     """Parses LLM generated JSON args, trying various repair strategies if args are not valid JSON."""

--- a/nearai/agents/tool_json_helper.py
+++ b/nearai/agents/tool_json_helper.py
@@ -8,6 +8,7 @@ def _ending_transform(x):
     else:
         raise json.JSONDecodeError("Try next transform", x, len(x))
 
+
 def parse_json_args(signature: dict, args: str):
     """Parses LLM generated JSON args, trying various repair strategies if args are not valid JSON."""
     # if args is empty or an empty json object check if the function has no arguments
@@ -68,4 +69,3 @@ def parse_json_args_based_on_signature(signature: dict, args: str):
             raw_value = raw_value[1:-1]
         parameter_values[param] = raw_value
     return parameter_values
-

--- a/nearai/agents/tool_json_helper.py
+++ b/nearai/agents/tool_json_helper.py
@@ -1,6 +1,7 @@
 import json
 import re
 
+from nearai.agents.models.tool_definition import ToolDefinition, ToolFunction, ToolParameterProperty, ToolParameters
 
 def _ending_transform(x):
     if x.endswith('}"') or x.endswith("}}"):
@@ -69,3 +70,31 @@ def parse_json_args_based_on_signature(signature: dict, args: str):
             raw_value = raw_value[1:-1]
         parameter_values[param] = raw_value
     return parameter_values
+
+
+def parse_tool_definition_based_on_mcp_tool(mcp_tool) -> ToolDefinition:
+    """Parses an MCP tool into a registry tool definition."""
+    tool_parameters = ToolParameters(
+        type="object",
+        properties={},
+        required=[],
+    )
+    for param_name, param_schema in mcp_tool.inputSchema.get("properties", {}).items():
+        param_property = ToolParameterProperty(
+            type=param_schema.get("type", "string"),
+            description=param_schema.get("description", ""),
+        )
+
+        if param_schema.get("enum", None):
+            param_property.enum = param_schema.get("enum", None)
+
+        tool_parameters.properties[param_name] = param_property
+
+    return ToolDefinition(
+        type="function",
+        function=ToolFunction(
+            name=mcp_tool.name,
+            description=mcp_tool.description,
+            parameters=tool_parameters
+        )
+    )

--- a/nearai/agents/tool_registry.py
+++ b/nearai/agents/tool_registry.py
@@ -1,6 +1,8 @@
 import inspect
 from typing import Any, Callable, Dict, Literal, Optional, _GenericAlias, get_type_hints  # type: ignore
+
 from nearai.agents.models.tool_definition import MCPTool
+
 
 class ToolRegistry:
     """A registry for tools that can be called by the agent.
@@ -42,7 +44,7 @@ class ToolRegistry:
             try:
                 return await call_tool(mcp_tool.name, kwargs)
             except Exception as e:
-                raise Exception(f"Error calling tool {mcp_tool.name} with arguments {kwargs}: {e}")
+                raise Exception(f"Error calling tool {mcp_tool.name} with arguments {kwargs}: {e}") from e
 
         tool.__name__ = mcp_tool.name
         tool.__doc__ = mcp_tool.description

--- a/nearai/agents/tool_registry.py
+++ b/nearai/agents/tool_registry.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Callable, Dict, Literal, Optional, _GenericAlias, get_type_hints
+from typing import Any, Callable, Dict, Literal, Optional, _GenericAlias, get_type_hints  # type: ignore
 from nearai.agents.models.tool_definition import MCPTool
 
 class ToolRegistry:


### PR DESCRIPTION
Enabling a MCP tool to be registered with the tool registry

Agent to test this changes: https://app.near.ai/agents/bernardomafra.near/example-mcp-agent/latest/source