### PR TITLE
bumped agentkit versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.1.17 (2025-04-09)
+
+### Feat
+
+- upgrade coinbase-agentkit dependency to 0.4.0 (#1097)
+- upgrade coinbase-agentkit-langchain dependency to 0.3.0 (#1097)
+
 ## v0.1.16 (2025-03-13)
 
 ### Feat

--- a/aws_runner/frameworks/requirements-agentkit.txt
+++ b/aws_runner/frameworks/requirements-agentkit.txt
@@ -15,11 +15,11 @@ cdp-sdk >= 0.15.0
 
 # Coinbase AgentKit Integration
 # https://github.com/coinbase/agentkit
-coinbase-agentkit >= 0.1.2
+coinbase-agentkit >= 0.4.0
 
 # LangChain integration for Coinbase AgentKit
 # https://github.com/coinbase/agentkit
-coinbase-agentkit-langchain >= 0.1.0
+coinbase-agentkit-langchain >= 0.3.0
 
 # Datadog tracing library
 # https://github.com/DataDog/dd-trace-py


### PR DESCRIPTION
updated python aws runners requirements for agentkit framework to use latest library versions

this closes https://github.com/nearai/nearai/issues/1097