### PR TITLE
fix: promote meteor as recommended path for account creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,7 @@ nearai version
 
 ### Log In
 
-Login to NEAR AI with your NEAR Account. If you don't have one, you can create one [here](https://wallet.near.org/).
-
-Currently supported NEAR wallets:
-- My NEAR Wallet
-- Sender
-- Meteor
-- Bitte
+Login to NEAR AI with your NEAR Account. If you don't have one, we recommend creating a free account with [Meteor Wallet](https://wallet.meteorwallet.app).
 
 ```bash
 nearai login 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -69,19 +69,11 @@ Additionally, we recommend creating a virtual environment to avoid conflicts wit
 
 ## Login to NEAR AI
 
-To create a new agent, first login with a [NEAR Account](https://wallet.near.org/):
+To create a new agent, first login with a NEAR Account. If you don't have one, we recommend creating a free account with [Meteor Wallet](https://wallet.meteorwallet.app):
 
 ``` bash
 nearai login
 ```
-
-??? tip "Don't have a NEAR Account?"
-
-    If you do not have a NEAR account, you can create one for free using wallets listed at [wallet.near.org](https://wallet.near.org/). 
-    
-    If you are unsure of which one to choose, try out [Bitte](https://wallet.bitte.ai) or [Meteor Wallet](https://wallet.meteorwallet.app/add_wallet/create_new).
-
-You'll be provided with a URL to login with your NEAR account.
 
 Example:
 


### PR DESCRIPTION
Devs new to crypto have been confused on account creation step, as MNW asks to fund the account. To help mitigate this confusion, this PR promotes Meteor Wallet as the preferred method of creating a free account.