### PR TITLE
fix: add local=true when running interactive from list

### DIFF
--- a/nearai/cli.py
+++ b/nearai/cli.py
@@ -712,6 +712,7 @@ class AgentCli:
         assert_user_auth()
 
         if agent is None:
+            local = True
             # List available agents in the registry folder
             registry_path = Path(get_registry_folder())
             if not registry_path.exists():


### PR DESCRIPTION
If users are running `nearai agent interactive` without specifying an agent it shows them of their local agents they created to choose from, but then errors as they also need to pass `--local`. We should handle this for them by setting local to `true` when an agent is not specified. 

Helps fix #1061 