### PR TITLE
Update cli.md documentation clarifying login method --remote 

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,7 +72,7 @@ Additionally, we recommend creating a virtual environment to avoid conflicts wit
 To create a new agent, first login with a NEAR Account. If you don't have one, we recommend creating a free account with [Meteor Wallet](https://wallet.meteorwallet.app):
 
 ``` bash
-nearai login
+nearai login # OR nearai login --remote
 ```
 
 Example:


### PR DESCRIPTION
I came across this hiccup and hope this clarification will help others.  
I propose adding a small clarification note to use nearai login -- remote method when user is running virtual codespace, in such case localhost will not work.