### PR TITLE
fix: correctly convert input `content`

### DIFF
--- a/hub/api/v1/models.py
+++ b/hub/api/v1/models.py
@@ -308,7 +308,8 @@ class Message(SQLModel, table=True):
             if isinstance(self.content, Iterator):
                 self.content = [
                     TextContentBlock(text=Text(value=content["text"], annotations=[]), type="text")
-                    if content["type"] == "text" else content
+                    if content["type"] == "text"
+                    else content
                     for content in self.content
                 ]
 

--- a/hub/api/v1/models.py
+++ b/hub/api/v1/models.py
@@ -305,6 +305,13 @@ class Message(SQLModel, table=True):
             if isinstance(self.content, str):
                 self.content = [TextContentBlock(text=Text(value=self.content, annotations=[]), type="text")]
 
+            if isinstance(self.content, Iterator):
+                self.content = [
+                    TextContentBlock(text=Text(value=content["text"], annotations=[]), type="text")
+                    if content["type"] == "text" else content
+                    for content in self.content
+                ]
+
             # Handle both Pydantic models and dictionaries
             self.content = [
                 content.model_dump() if hasattr(content, "model_dump") else content for content in self.content


### PR DESCRIPTION
[`create_message`](https://github.com/nearai/nearai/blob/b3cf86efae03e58ea47ce8dbf85afbb4a7d47493/hub/api/v1/thread_routes.py#L377) receive as input a `MessageCreateParam` which can [either be a `string` or a list of pre-determinated objects](https://github.com/nearai/nearai/blob/main/hub/api/v1/thread_routes.py#L223), one of which is a `TextContentBlockParam`

Currently, we are only handling the logic for when the input is a `string`, which we correctly convert into an output `Message`. However, the code breaks when the user inputs a `TextContentBlockParam`, which is very useful in situations such as sending text and an image in the same message.

This fix handles the case for when a `TextContentBlockParam` is input, correctly converting it into a valid output `Messages`