### PR TITLE
Add attachments to messages

### DIFF
--- a/nearai/agents/environment.py
+++ b/nearai/agents/environment.py
@@ -920,6 +920,7 @@ class Environment(object):
                 "id": m.id,
                 "content": "\n".join([c.text.value for c in m.content]),  # type: ignore
                 "role": m.role,
+                "attachments": m.attachments,
             }
             for m in messages
         ]


### PR DESCRIPTION
This PR allows messages to access attachments, which we will start using for agents to access files uploaded through the hub (#1119)