### PR TITLE
Add option to decide how to decode files

### DIFF
--- a/nearai/agents/environment.py
+++ b/nearai/agents/environment.py
@@ -680,7 +680,7 @@ class Environment(object):
 
         self.list_files_from_thread = list_files_from_thread
 
-        def read_file_by_id(file_id: str, decode: str | None = "utf-8"):
+        def read_file_by_id(file_id: str, decode: Union[str, None] = "utf-8"):
             """Read a file from the thread."""
             content = hub_client.files.content(file_id).content
 
@@ -694,7 +694,7 @@ class Environment(object):
         def write_file(
             filename: str,
             content: Union[str, bytes],
-            encoding: str | None = "utf-8",
+            encoding: Union[str, None] = "utf-8",
             filetype: str = "text/plain",
             write_to_disk: bool = True,
         ) -> FileObject:
@@ -961,7 +961,7 @@ class Environment(object):
         """Returns temp dir for primary agent where execution happens."""
         return self.get_primary_agent_temp_dir()
 
-    def read_file(self, filename: str, decode: str | None = "utf-8") -> Optional[Union[bytes, str]]:
+    def read_file(self, filename: str, decode: Union[str, None] = "utf-8") -> Optional[Union[bytes, str]]:
         """Reads a file from the environment or thread."""
         file_content: Optional[Union[bytes, str]] = None
         # First try to read from local filesystem


### PR DESCRIPTION
Right now our platform assumes that users will only try to use text files, and thus tries to decode every single file using `utf-8`

Now that we added the ability to use attachments, it is likely that agents will interact with files that are not text, for example images or audio

This commit adds a `decode` field to all "read" operations, trying to keep as much compatibility as possible with the current implementation. This is, by default we try to decode the file as utf-8, but this can be skipped