### PR TITLE
default to main thread for streaming completions

### DIFF
--- a/nearai/agents/environment.py
+++ b/nearai/agents/environment.py
@@ -1141,7 +1141,11 @@ class Environment(object):
             kwargs.setdefault("extra_headers", {}).update(
                 {
                     k: v
-                    for k, v in {"run_id": self._run_id, "thread_id": thread_id, "message_id": message_id}.items()
+                    for k, v in {
+                        "run_id": self._run_id,
+                        "thread_id": thread_id if thread_id else self._thread_id,
+                        "message_id": message_id,
+                    }.items()
                     if v is not None
                 }
             )


### PR DESCRIPTION
A different thread_id can be passed to completions for streaming but usually the main thread will apply