### PR TITLE
fix: standardize docstring category format

### DIFF
--- a/nearai/cli.py
+++ b/nearai/cli.py
@@ -117,8 +117,7 @@ class RegistryCli:
       --star (str) :
         Show items starred by a specific user
 
-    Examples
-    --------
+    Examples:
       # Upload an agent to the registry
       nearai registry upload ./path/to/agent
 
@@ -145,12 +144,10 @@ class RegistryCli:
         Includes metadata and available provider matches for models.
 
         Args:
-        ----
           entry (str) :
             Entry location of the item to display information for (format: namespace/name/version)
 
         Examples:
-        --------
           # Show information about a specific registry item
           nearai registry info example.near/agent-name/0.0.3
 
@@ -193,7 +190,6 @@ class RegistryCli:
         that can be customized for your agent or model.
 
         Args:
-        ----
           local_path : str
             Path to the directory where the metadata template will be created
           category : str
@@ -202,7 +198,6 @@ class RegistryCli:
             Description of the item
 
         Examples:
-        --------
           # Create a metadata template in the current directory
           nearai registry metadata-template
 
@@ -272,7 +267,6 @@ class RegistryCli:
         You can filter the results by namespace, category, tags, and other criteria to find specific items.
 
         Args:
-        ----
           namespace (str) :
             Filter items by namespace/user account (example.near)
           category (str) :
@@ -291,7 +285,6 @@ class RegistryCli:
             Show items starred by a specific user
 
         Examples:
-        --------
           # List all items in the registry
           nearai registry list
 
@@ -359,12 +352,10 @@ class RegistryCli:
         Looks for a metadata.json file in the given directory and updates the remote metadata with the new values.
 
         Args:
-        ----
           local_path (str) :
             Path to the directory containing the item to update
 
         Examples:
-        --------
           # Update metadata for the item in the current directory
           nearai registry update
 
@@ -405,12 +396,10 @@ class RegistryCli:
         This command helps keep the registry up-to-date with the latest models from various providers.
 
         Args:
-        ----
           dry_run (bool) :
             Perform a dry run without actually uploading
 
         Examples:
-        --------
           # Perform a dry run to see what would be uploaded
           nearai registry upload-unregistered-common-provider-models
 
@@ -473,7 +462,6 @@ class RegistryCli:
         """Upload an item to the NEAR AI registry for public use.
 
         Args:
-        ----
           local_path (str) :
             Path to the agent directory
           bump (bool) :
@@ -484,7 +472,6 @@ class RegistryCli:
             Bump with major version increment (1.5.2 → 2.0.0)
 
         Examples:
-        --------
           # Upload an item in the current directory
           nearai registry upload
 
@@ -655,14 +642,12 @@ class RegistryCli:
         This allows you to use or inspect agents, models, datasets, etc. that have been published by others.
 
         Args:
-        ----
           entry_location (str) :
             Entry location of the item to download (format: namespace/name/version)
           force (bool) :
             Force download even if the item already exists locally
 
         Examples:
-        --------
           # Download a specific registry item
           nearai registry download example.near/agent-name/0.0.3
 
@@ -698,8 +683,7 @@ class ConfigCli:
       --local (bool) :
         Store the configuration value in the local config file
 
-    Examples
-    --------
+    Examples:
       # View all configuration values
       nearai config show
 
@@ -775,8 +759,7 @@ class BenchmarkCli:
       --offset (int) :
         Offset for pagination
 
-    Examples
-    --------
+    Examples:
       # Run a benchmark on a dataset with a solver strategy
       nearai benchmark run my-dataset my-solver-strategy --max-concurrent 4 --force
 
@@ -833,7 +816,6 @@ class BenchmarkCli:
         Results are cached in the database for subsequent runs unless --force is used.
 
         Args:
-        ----
           dataset (str) :
             Name of the dataset to benchmark against
           solver_strategy (str) :
@@ -854,7 +836,6 @@ class BenchmarkCli:
             Additional arguments passed to the solver strategy
 
         Examples:
-        --------
             # Run a benchmark with default settings
             nearai benchmark run my-dataset my-solver-strategy
 
@@ -931,7 +912,6 @@ class BenchmarkCli:
         paginated using limit and offset parameters.
 
         Args:
-        ----
           namespace (str) :
             Filter results by namespace
           benchmark (str) :
@@ -946,7 +926,6 @@ class BenchmarkCli:
             Number of results to skip
 
         Examples:
-        --------
             # List all benchmarks with default pagination
             nearai benchmark list
 
@@ -1022,8 +1001,7 @@ class EvaluationCli:
       --verbose (bool) :
         Show verbose information including detailed logs
 
-    Examples
-    --------
+    Examples:
       # Display evaluation table with default settings
       nearai evaluation table
 
@@ -1219,8 +1197,7 @@ class AgentCli:
       --stream (bool) :
         Stream the agent's output, only works with agents that stream completions
 
-    Examples
-    --------
+    Examples:
       # Create a new agent interactively (Step-by-step prompts)
       nearai agent create
 
@@ -1252,8 +1229,7 @@ class AgentCli:
 
         This launches a local server for testing and developing agent functionality in a browser-based environment.
 
-        Examples
-        --------
+        Examples:
           # Start the local development server
           nearai agent dev
 
@@ -1274,12 +1250,10 @@ class AgentCli:
         This launches a Streamlit interface showing the agent's structure, code, and metadata.
 
         Args:
-        ----
           path : str
             Path to the agent directory to inspect (required)
 
         Examples:
-        --------
           # Inspect a local agent
           nearai agent inspect ./path/to/agent
 
@@ -1309,7 +1283,6 @@ class AgentCli:
         pass the path to the agent followed by the --local flag. (See examples below.)
 
         Args:
-        ----
           agent (str) :
             Path to the agent directory or agent ID (optional)
           thread_id (str) :
@@ -1327,7 +1300,6 @@ class AgentCli:
 
 
         Examples:
-        --------
           # Select from a list of agents to run that you created or downloaded
           nearai agent interactive
 
@@ -1489,7 +1461,6 @@ class AgentCli:
         This is useful for automation or when you don't need an ongoing conversation.
 
         Args:
-        ----
           agent (str) :
             Path to the agent directory or agent ID (required)
           task (str) :
@@ -1510,7 +1481,6 @@ class AgentCli:
             Stream the agent's output, only works with agents that stream completions
 
         Examples:
-        --------
           # Send a simple task to an agent
           nearai agent task --agent example.near/agent-name/0.0.3 --task "Summarize this article: https://example.com/article"
 
@@ -1681,7 +1651,6 @@ class AgentCli:
         """Create a new AI agent from scratch or fork existing ones.
 
         Args:
-        ----
           name (str) :
             Name for the new agent (optional).
           description (str) :
@@ -1690,7 +1659,6 @@ class AgentCli:
             Path to an existing agent to fork (format: namespace/agent_name/version).
 
         Examples:
-        --------
           # Create a new agent step-by-step with prompts
           nearai agent create
 
@@ -1755,8 +1723,7 @@ class VllmCli:
       --gpu-memory-utilization (float) :
         Fraction of GPU memory to use
 
-    Examples
-    --------
+    Examples:
       # Run VLLM server with default settings
       nearai vllm run --model mistralai/Mistral-7B-Instruct-v0.1
 
@@ -1776,7 +1743,6 @@ class VllmCli:
         optimizing performance and resource utilization.
 
         Args:
-        ----
           **kwargs : (dict)
             Keyword arguments that can include:
             model (str):
@@ -1791,7 +1757,6 @@ class VllmCli:
               Fraction of GPU memory to use
 
         Examples:
-        --------
             # Run VLLM server with default settings
             nearai vllm run --model mistralai/Mistral-7B-Instruct-v0.1
 
@@ -1843,8 +1808,7 @@ class HubCLI:
       --info (bool) :
         Display system information about the request
 
-    Examples
-    --------
+    Examples:
       # Chat with the default model
       nearai hub chat --query "Explain quantum computing in simple terms"
 
@@ -1864,7 +1828,6 @@ class HubCLI:
         experience with various parameters.
 
         Args:
-        ----
             **kwargs : (dict)
                 Keyword arguments that can include:
                 query (str):
@@ -1880,7 +1843,6 @@ class HubCLI:
                 Additional parameters passed to the model
 
         Examples:
-        --------
             # Chat with the default model
             nearai hub chat --query "Explain quantum computing in simple terms"
 
@@ -1911,8 +1873,7 @@ class LogoutCLI:
     Commands:
       nearai logout : Logout and remove authentication data
 
-    Examples
-    --------
+    Examples:
       # Remove authentication data
       nearai logout
 
@@ -1959,8 +1920,7 @@ class LoginCLI:
       --nonce (str) :
         Nonce value for authentication security
 
-    Examples
-    --------
+    Examples:
       # Login using web-based flow
       nearai login
 
@@ -2045,8 +2005,7 @@ class PermissionCli:
       permission (str) :
         The permission to grant or revoke (leave empty on revoke to remove all permissions)
 
-    Examples
-    --------
+    Examples:
       # Grant model access permission to an account
       nearai permission grant alice.near model_access
 


### PR DESCRIPTION
Some examples were missing a `:` and had an underline `-----` which was performed on accident when running a `--fix` with linting check. (Did not like colon AND underline but only for class docstrings 🙃 ) 

This PR standardizes everything to have : and removes all underlines which makes everyone happy. :) 