### PR TITLE
Remove models link from resources

### DIFF
--- a/hub/demo/src/components/Navigation.tsx
+++ b/hub/demo/src/components/Navigation.tsx
@@ -76,11 +76,6 @@ const resourcesNavItems = env.NEXT_PUBLIC_CONSUMER_MODE
         icon: ENTRY_CATEGORY_LABELS.evaluation.icon,
       },
       {
-        label: 'Models',
-        path: '/models',
-        icon: ENTRY_CATEGORY_LABELS.model.icon,
-      },
-      {
         label: 'Documentation',
         path: 'https://docs.near.ai',
         target: '_blank',


### PR DESCRIPTION
We will deprecate `category=model` registry entries and will increase integration with fireworks, Open AI, and Anthropic.