### PR TITLE
Obfuscate encryption key in API

### DIFF
--- a/hub/api/v1/registry.py
+++ b/hub/api/v1/registry.py
@@ -125,6 +125,17 @@ def get(entry_location: EntryLocation = Body()) -> RegistryEntry:
         return entry
 
 
+def obfuscate_encryption_key(data: dict):
+    """Obfuscate encryption key in data structure."""
+    result = {}
+    for k, v in data.items():
+        if k == "encryption_key":
+            result[k] = "<secret>"
+        else:
+            result[k] = v
+    return result
+
+
 def get_read_access(
     entry: RegistryEntry = Depends(get),
     auth: Optional[AuthToken] = Depends(get_optional_auth),
@@ -132,6 +143,8 @@ def get_read_access(
     current_account_id = auth.account_id if auth else None
     if entry.is_private() and entry.namespace != current_account_id:
         raise HTTPException(status_code=403, detail="Unauthorized")
+    if entry.namespace != current_account_id:
+        entry.details = obfuscate_encryption_key(entry.details)
     return entry
 
 


### PR DESCRIPTION
Encrypted entries can be read by either author or a user who knows encryption key.
Encrypted entries can be run by anyone.

Encrypted entries will be introduced in 3 PRs:
- 1st PR (this): obfuscate encryption key in API, so that only the author can fetch it.
- 2nd PR: Cli changes to encrypt/decrypt entries.
- 3rd PR: Decrypt entries in runners.