### PR TITLE
Filter out agent logs from main window.

### DIFF
--- a/hub/demo/src/components/AgentRunner.tsx
+++ b/hub/demo/src/components/AgentRunner.tsx
@@ -189,7 +189,10 @@ export const AgentRunner = ({
     },
   });
 
-  const isRunning = _chatMutation.isPending;
+  const isRunning =
+    _chatMutation.isPending ||
+    thread?.run?.status === 'queued' ||
+    thread?.run?.status === 'in_progress';
 
   const isLoading = !!auth && !!threadId && !thread && !isRunning;
 

--- a/hub/demo/src/components/AgentRunner.tsx
+++ b/hub/demo/src/components/AgentRunner.tsx
@@ -209,7 +209,9 @@ export const AgentRunner = ({
 
   const logMessages = useMemo(() => {
     return (thread ? Object.values(thread.messagesById) : []).filter(
-      (message) => message.metadata?.message_type?.startsWith('system:') || message.metadata?.message_type?.startsWith('agent:log'),
+      (message) =>
+        message.metadata?.message_type?.startsWith('system:') ||
+        message.metadata?.message_type?.startsWith('agent:log'),
     );
   }, [thread]);
 
@@ -219,7 +221,11 @@ export const AgentRunner = ({
       ...optimisticMessages.map((message) => message.data),
     ].filter(
       (message) =>
-        showLogs || !(message.metadata?.message_type?.startsWith('system:') || message.metadata?.message_type?.startsWith('agent:log')),
+        showLogs ||
+        !(
+          message.metadata?.message_type?.startsWith('system:') ||
+          message.metadata?.message_type?.startsWith('agent:log')
+        ),
     );
   }, [thread, optimisticMessages, showLogs]);
 

--- a/hub/demo/src/components/AgentRunner.tsx
+++ b/hub/demo/src/components/AgentRunner.tsx
@@ -189,10 +189,7 @@ export const AgentRunner = ({
     },
   });
 
-  const isRunning =
-    _chatMutation.isPending ||
-    thread?.run?.status === 'queued' ||
-    thread?.run?.status === 'in_progress';
+  const isRunning = _chatMutation.isPending;
 
   const isLoading = !!auth && !!threadId && !thread && !isRunning;
 

--- a/hub/demo/src/components/AgentRunner.tsx
+++ b/hub/demo/src/components/AgentRunner.tsx
@@ -209,7 +209,7 @@ export const AgentRunner = ({
 
   const logMessages = useMemo(() => {
     return (thread ? Object.values(thread.messagesById) : []).filter(
-      (message) => message.metadata?.message_type?.startsWith('system:'),
+      (message) => message.metadata?.message_type?.startsWith('system:') || message.metadata?.message_type?.startsWith('agent:log'),
     );
   }, [thread]);
 
@@ -219,7 +219,7 @@ export const AgentRunner = ({
       ...optimisticMessages.map((message) => message.data),
     ].filter(
       (message) =>
-        showLogs || !message.metadata?.message_type?.startsWith('system:'),
+        showLogs || !(message.metadata?.message_type?.startsWith('system:') || message.metadata?.message_type?.startsWith('agent:log')),
     );
   }, [thread, optimisticMessages, showLogs]);
 


### PR DESCRIPTION
No need to show them in output since agent logs are now available in agent_log.txt

Deployed.