### PR TITLE
Deprecate --category=model entries in Cli and provide options

### DIFF
--- a/nearai/agents/agent.py
+++ b/nearai/agents/agent.py
@@ -310,6 +310,7 @@ class Agent(object):
             # switch to user env.agent_runner_user (Unix-only)
             if agent_runner_user:
                 import pwd
+
                 user_info = pwd.getpwnam(agent_runner_user)
                 os.setgid(user_info.pw_gid)
                 os.setuid(user_info.pw_uid)

--- a/nearai/cli.py
+++ b/nearai/cli.py
@@ -71,7 +71,7 @@ from nearai.shared.client_config import (
     IDENTIFIER_PATTERN as PATTERN,
 )
 from nearai.shared.naming import NamespacedName, create_registry_name
-from nearai.shared.provider_models import ProviderModels, get_provider_namespaced_model
+from nearai.shared.provider_models import ProviderModels, fetch_models_from_provider, get_provider_namespaced_model
 from nearai.tensorboard_feed import TensorboardCli
 
 
@@ -301,6 +301,30 @@ class RegistryCli:
           nearai registry list --show-all
 
         """
+        # Check if we're listing models specifically and provide alternative options
+        if category.lower() == "model":
+            print("\n⚠️  The category=model entries in the registry are deprecated.")
+            print("We recommend using Fireworks, OpenAI, Anthropic, Crynux, or other provider models instead.")
+            print("\nEnter one of the following options:")
+            print("- registry        : See the registry models anyway")
+            print("- nearai          : List models from NEAR AI endpoint (Fireworks models, free inference)")
+            print("- openai          : List available OpenAI models. Requires OPENAI_API_KEY.")
+            print("- anthropic       : List available Anthropic models. Requires ANTHROPIC_API_KEY.")
+            print(
+                "- crynux          : List available Crynux models (framework support, public API key, low rate limit)"
+            )
+            print("- nearai          : List models from nearai endpoint (should be the same as fireworks)")
+            print("(May require api keys or correct moon phase)")
+            print("")
+
+            choice = input("\nYour choice: ").strip().lower()
+
+            if choice != "registry":
+                models = fetch_models_from_provider(choice)
+                for model in models:
+                    print(f"{model}")
+                return
+
         # Make sure tags is a comma-separated list of tags
         tags_l = parse_tags(tags)
         tags = ",".join(tags_l)

--- a/nearai/shared/provider_models.py
+++ b/nearai/shared/provider_models.py
@@ -1,3 +1,4 @@
+import os
 import re
 from functools import cached_property
 from typing import Dict, List, Optional, Tuple, cast
@@ -128,3 +129,62 @@ class ProviderModels:
                 continue
             result.append(available_matches)
         return result
+
+
+def fetch_models_from_provider(provider: str) -> List[Dict]:
+    """Fetch models from a specific provider.
+
+    Args:
+        provider: The provider name ("nearai", "fireworks", "openai", "anthropic", "crynux")
+
+    Returns:
+        List of model dictionaries
+
+    The user is responsible for setting the appropriate API key in environment variables:
+    - FIREWORKS_API_KEY for Fireworks
+    - OPENAI_API_KEY for OpenAI
+    - ANTHROPIC_API_KEY for Anthropic
+
+    """
+    if provider == "nearai":
+        return fetch_models_from_endpoint("https://api.near.ai/v1/models", provider=provider)
+    if provider == "fireworks":
+        return fetch_models_from_endpoint(
+            "https://api.fireworks.ai/inference/v1/models",
+            provider=provider,
+            api_key=os.environ.get("FIREWORKS_API_KEY"),
+        )
+    if provider == "openai":
+        return fetch_models_from_endpoint(
+            "https://api.openai.com/v1/models", provider=provider, api_key=os.environ.get("OPENAI_API_KEY")
+        )
+    if provider == "anthropic":
+        return fetch_models_from_endpoint(
+            "https://api.anthropic.com/v1/models", provider=provider, api_key=os.environ.get("ANTHROPIC_API_KEY")
+        )
+    if provider == "crynux":
+        return fetch_models_from_endpoint(
+            "https://bridge.crynux.ai/v1/models",
+            provider=provider,
+            api_key="wo19nkaeWy4ly34iexE7DKtNIY6fZWErCAU8l--735U=",
+        )
+    print(f"Unrecognized provider: {provider}")
+    exit(1)
+
+
+def fetch_models_from_endpoint(endpoint: str, provider: str, api_key: str | None = None) -> List[Dict]:
+    try:
+        headers = {}
+        if api_key:
+            # Different providers may use different auth header formats
+            if provider in ["openai", "fireworks", "crynux"]:
+                headers["Authorization"] = f"Bearer {api_key}"
+            elif provider == "anthropic":
+                headers["x-api-key"] = api_key
+        # Make the API request
+        response = requests.get(endpoint, headers=headers)
+        response.raise_for_status()
+        return response.json()["data"]
+    except Exception as e:
+        print(f"Error fetching models: {str(e)}")
+        exit(1)


### PR DESCRIPTION
```
[0] nearai registry list --category=model

⚠️  The category=model entries in the registry are deprecated.
We recommend using Fireworks, OpenAI, Anthropic, Crynux, or other provider models instead.

Enter one of the following options:
- registry        : See the registry models anyway
- nearai          : List models from NEAR AI endpoint (Fireworks models, free inference)
- openai          : List available OpenAI models. Requires OPENAI_API_KEY.
- anthropic       : List available Anthropic models. Requires ANTHROPIC_API_KEY.
- crynux          : List available Crynux models (framework support, public API key, low rate limit)
- nearai          : List models from nearai endpoint (should be the same as fireworks)
(May require api keys or correct moon phase)


Your choice:
```