### PR TITLE
Feat: make transformers and peft optional finetune dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "openai>=1.66.2,<2.0.0",
     "pandas-stubs>=2.2.2.240603,<3.0.0",
     "pathspec>=0.11.0",
-    "peft>=0.10.0,<0.11.0",
     "psutil>=5.9.5,<6.0.0",
     "pydantic>=2.7.1,<3.0.0",
     "pydantic-core>=2.18.4,<3.0.0",
@@ -36,7 +35,6 @@ dependencies = [
     "tabulate>=0.9.0,<0.10.0",
     "tenacity>=8.2.3,<9.0.0",
     "tqdm>=4.66.4,<5.0.0",
-    "transformers>=4.40.2,<5.0.0",
     "types-cffi>=1.16.0.20240331,<2.0.0",
     "types-colorama>=0.4.15.20240311,<0.5.0",
     "types-psutil>=6.0.0.20240621,<7.0.0",
@@ -65,6 +63,10 @@ explatform = [
     "flask>=3.0.3,<4.0.0",
     "gunicorn>=22.0.0,<23.0.0",
     "shortuuid>=1.0.0,<2.0.0"
+]
+finetune = [
+    "transformers>=4.40.2,<5.0.0",
+    "peft>=0.10.0,<0.11.0"
 ]
 hub = [
     "fastapi-cli>=0.0.4,<1.0.0",


### PR DESCRIPTION
"transformers" and "peft" seem like they should be an optional dependency if you are going to use the fine tuning api. It should not be included in every build unless explicitly desired, since the installation of pytorch and CUDA libraries (from pytorch) bloats images by 10x. For instance, my docker image with transformers and peft was 18GB. With this PR, it is 4GB.  