### PR TITLE
chore: updated api url used in docker

### DIFF
--- a/.docker/Dockerfile.scheduler
+++ b/.docker/Dockerfile.scheduler
@@ -7,7 +7,7 @@ ARG NEARAISCHEDULER_NONCE
 RUN mkdir -p ~/.nearai && \
     cat <<EOF > ~/.nearai/config.json
 {
-    "api_url": "https://redacted.api.near.ai",
+    "api_url": "https://api.near.ai",
     "auth": {
         "account_id": "${NEARAISCHEDULER_ACCOUNT_ID}",
         "signature": "${NEARAISCHEDULER_SIGNATURE}",

--- a/.docker/Dockerfile.worker
+++ b/.docker/Dockerfile.worker
@@ -7,7 +7,7 @@ ARG NEARAIWORKER_NONCE
 RUN mkdir -p ~/.nearai && \
     cat <<EOF > ~/.nearai/config.json
 {
-    "api_url": "https://redacted.api.near.ai",
+    "api_url": "https://api.near.ai",
     "auth": {
         "account_id": "${NEARAIWORKER_ACCOUNT_ID}",
         "signature": "${NEARAIWORKER_SIGNATURE}",


### PR DESCRIPTION
Will need Lambda deploys after merge. 

This is a clean up PR and not urgent.